### PR TITLE
Feature/#43 - 공통 드롭다운 메뉴 컴포넌트 구현 

### DIFF
--- a/src/components/DropDownMenu/index.stories.tsx
+++ b/src/components/DropDownMenu/index.stories.tsx
@@ -1,0 +1,83 @@
+import type {Meta, StoryObj} from '@storybook/react';
+import {action} from '@storybook/addon-actions';
+import {View} from 'react-native';
+import {DropDownMenu} from '.';
+
+const meta = {
+  title: 'components/DropDownMenu',
+  component: DropDownMenu,
+  decorators: [
+    StoryComponent => {
+      return (
+        <View style={{flex: 1, backgroundColor: '#FAFAFA', padding: 20}}>
+          <StoryComponent />
+        </View>
+      );
+    },
+  ],
+} satisfies Meta<typeof DropDownMenu>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+// 관리자가 멤버의 프로필을 조회하는 경우
+export const Choice4: Story = {
+  args: {
+    menus: [
+      {
+        label: '다운로드',
+        isDownload: true,
+        onPress: action('onPress'),
+      },
+      {
+        label: '삭제하기',
+        isDelete: true,
+        onPress: action('onPress'),
+      },
+      {
+        label: '수정하기',
+        onPress: action('onPress'),
+      },
+      {
+        label: '공유하기',
+        onPress: action('onPress'),
+      },
+    ],
+  },
+};
+
+export const Choice3: Story = {
+  args: {
+    menus: [
+      {
+        label: '게시글 고정',
+        onPress: action('onPress'),
+      },
+      {
+        label: '수정하기',
+        onPress: action('onPress'),
+      },
+      {
+        label: '삭제하기',
+        isDelete: true,
+        onPress: action('onPress'),
+      },
+    ],
+  },
+};
+
+export const Choice2: Story = {
+  args: {
+    menus: [
+      {
+        label: '동아리 설정',
+        onPress: action('onPress'),
+      },
+      {
+        label: '동아리 탈퇴',
+        onPress: action('onPress'),
+      },
+    ],
+  },
+};

--- a/src/components/DropDownMenu/index.style.ts
+++ b/src/components/DropDownMenu/index.style.ts
@@ -1,0 +1,27 @@
+import styled from '@emotion/native';
+
+export const Container = styled.View`
+  width: 120px;
+  height: auto;
+  background-color: ${({theme}) => theme.colors.popup};
+  border-radius: 4px;
+`;
+
+export const MenuContainer = styled.TouchableOpacity`
+  display: flex;
+  align-items: center;
+  padding: 16px 0px;
+`;
+
+export const MenuText = styled.Text<{color: string}>`
+  color: ${({theme, color}) =>
+    theme.colors[color as keyof typeof theme.colors]};
+  white-space: nowrap;
+  ${({theme}) => theme.fonts.text1}
+`;
+
+export const Divider = styled.View`
+  height: 1px;
+  background-color: ${({theme}) => theme.colors.divider};
+  margin: 0px 4px;
+`;

--- a/src/components/DropDownMenu/index.tsx
+++ b/src/components/DropDownMenu/index.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import {Container, MenuContainer, MenuText, Divider} from './index.style';
+
+/**
+ * 공통 드롭다운 메뉴 컴포넌트 입니다.
+ * 메뉴 개수에 따라 레이아웃이 유동적으로 조정됩니다.
+ * 각 메뉴는 isDelete, isDownload props를 통해 스타일이 달라집니다.
+ * - 삭제하기 메뉴는 빨간색으로 표시
+ * - 다운로드 메뉴는 파란색으로 표시
+ * @author 이정선
+ */
+
+export type MenuProps = {
+  menus: {
+    label: string;
+    isDelete?: boolean;
+    isDownload?: boolean;
+    onPress: () => void;
+  }[];
+};
+
+export const DropDownMenu = ({menus}: MenuProps) => (
+  <Container>
+    {menus.map((menu, index) => (
+      <React.Fragment key={index}>
+        <MenuContainer onPress={menu.onPress}>
+          <MenuText
+            color={
+              menu.isDelete ? 'red' : menu.isDownload ? 'blue' : 'textPrimary'
+            }>
+            {menu.label}
+          </MenuText>
+        </MenuContainer>
+        {index !== menus.length - 1 && <Divider />}
+      </React.Fragment>
+    ))}
+  </Container>
+);

--- a/src/components/DropDownMenu/index.tsx
+++ b/src/components/DropDownMenu/index.tsx
@@ -22,8 +22,8 @@ export type MenuProps = {
 export const DropDownMenu = ({menus}: MenuProps) => (
   <Container>
     {menus.map((menu, index) => (
-      <React.Fragment key={index}>
-        <MenuContainer onPress={menu.onPress}>
+      <>
+        <MenuContainer activeOpacity={0.9} onPress={menu.onPress}>
           <MenuText
             color={
               menu.isDelete ? 'red' : menu.isDownload ? 'blue' : 'textPrimary'
@@ -32,7 +32,7 @@ export const DropDownMenu = ({menus}: MenuProps) => (
           </MenuText>
         </MenuContainer>
         {index !== menus.length - 1 && <Divider />}
-      </React.Fragment>
+      </>
     ))}
   </Container>
 );

--- a/src/components/DropDownMenu/index.tsx
+++ b/src/components/DropDownMenu/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import {Container, MenuContainer, MenuText, Divider} from './index.style';
+import {Menu} from './index.type';
 
 /**
  * 공통 드롭다운 메뉴 컴포넌트 입니다.
@@ -11,12 +12,7 @@ import {Container, MenuContainer, MenuText, Divider} from './index.style';
  */
 
 export type MenuProps = {
-  menus: {
-    label: string;
-    isDelete?: boolean;
-    isDownload?: boolean;
-    onPress: () => void;
-  }[];
+  menus: Menu[];
 };
 
 export const DropDownMenu = ({menus}: MenuProps) => (

--- a/src/components/DropDownMenu/index.type.ts
+++ b/src/components/DropDownMenu/index.type.ts
@@ -1,0 +1,6 @@
+export type Menu = {
+  label: string;
+  isDelete?: boolean;
+  isDownload?: boolean;
+  onPress: () => void;
+};


### PR DESCRIPTION
## 관련 이슈
- Resolves : #43 
 
## 작업 사항
- 공통 드롭다운 메뉴 컴포넌트를 구현했습니다.
- menu 리스트를 props로 받아오고 메뉴의 갯수에 맞게 레이아웃이 구성되도록 하였습니다.
- 디자인 상 다운로드 메뉴는 파란색, 삭제하기 메뉴는 빨간색으로 표시됩니다. props로 isDownload와 isDelete의 값을 받아와 메뉴 텍스트의 색상을 결정하도록 구현했습니다.

|choice 2|choice 3| choice 4|
|---|---|---|
|<img width="115" alt="스크린샷 2025-04-25 오후 5 23 41" src="https://github.com/user-attachments/assets/ceb1f4be-3ac2-40c3-96ae-7f903d49a2e8" />|<img width="120" alt="스크린샷 2025-04-25 오후 5 25 22" src="https://github.com/user-attachments/assets/99356342-3e17-47f3-a535-ba72548f2b7c" />|<img width="119" alt="스크린샷 2025-04-25 오후 5 23 34" src="https://github.com/user-attachments/assets/4795758a-011c-4664-8461-dc94e05dc0a1" />|


## 참고 사항
- 없습니다
