### PR TITLE
Refactor/#63 - Calendar Screen UX 개선 및 백엔드 단과 연결

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1422,7 +1422,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - react-native-safe-area-context (5.2.0):
+  - react-native-safe-area-context (5.4.1):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1435,8 +1435,8 @@ PODS:
     - React-featureflags
     - React-graphics
     - React-ImageManager
-    - react-native-safe-area-context/common (= 5.2.0)
-    - react-native-safe-area-context/fabric (= 5.2.0)
+    - react-native-safe-area-context/common (= 5.4.1)
+    - react-native-safe-area-context/fabric (= 5.4.1)
     - React-NativeModulesApple
     - React-RCTFabric
     - React-rendererdebug
@@ -1445,7 +1445,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - react-native-safe-area-context/common (5.2.0):
+  - react-native-safe-area-context/common (5.4.1):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1466,7 +1466,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - react-native-safe-area-context/fabric (5.2.0):
+  - react-native-safe-area-context/fabric (5.4.1):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1912,7 +1912,7 @@ PODS:
     - FirebaseCoreExtension
     - React-Core
     - RNFBApp
-  - RNGestureHandler (2.24.0):
+  - RNGestureHandler (2.25.0):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1933,32 +1933,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - RNReanimated (3.17.1):
-    - DoubleConversion
-    - glog
-    - hermes-engine
-    - RCT-Folly (= 2024.11.18.00)
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-debug
-    - React-Fabric
-    - React-featureflags
-    - React-graphics
-    - React-hermes
-    - React-ImageManager
-    - React-jsi
-    - React-NativeModulesApple
-    - React-RCTFabric
-    - React-rendererdebug
-    - React-utils
-    - ReactCodegen
-    - ReactCommon/turbomodule/bridging
-    - ReactCommon/turbomodule/core
-    - RNReanimated/reanimated (= 3.17.1)
-    - RNReanimated/worklets (= 3.17.1)
-    - Yoga
-  - RNReanimated/reanimated (3.17.1):
+  - RNReanimated (3.17.5):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1980,9 +1955,34 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - RNReanimated/reanimated/apple (= 3.17.1)
+    - RNReanimated/reanimated (= 3.17.5)
+    - RNReanimated/worklets (= 3.17.5)
     - Yoga
-  - RNReanimated/reanimated/apple (3.17.1):
+  - RNReanimated/reanimated (3.17.5):
+    - DoubleConversion
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2024.11.18.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-hermes
+    - React-ImageManager
+    - React-jsi
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - RNReanimated/reanimated/apple (= 3.17.5)
+    - Yoga
+  - RNReanimated/reanimated/apple (3.17.5):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -2005,7 +2005,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - RNReanimated/worklets (3.17.1):
+  - RNReanimated/worklets (3.17.5):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -2027,9 +2027,9 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - RNReanimated/worklets/apple (= 3.17.1)
+    - RNReanimated/worklets/apple (= 3.17.5)
     - Yoga
-  - RNReanimated/worklets/apple (3.17.1):
+  - RNReanimated/worklets/apple (3.17.5):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -2097,7 +2097,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - RNSVG (15.11.2):
+  - RNSVG (15.12.0):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -2117,9 +2117,9 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - RNSVG/common (= 15.11.2)
+    - RNSVG/common (= 15.12.0)
     - Yoga
-  - RNSVG/common (15.11.2):
+  - RNSVG/common (15.12.0):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -2493,7 +2493,7 @@ SPEC CHECKSUMS:
   React-microtasksnativemodule: 843f352b32aacbe13a9c750190d34df44c3e6c2c
   react-native-encrypted-storage: 569d114e329b1c2c2d9f8c84bcdbe4478dda2258
   react-native-image-picker: 84b261e109faa7312bca59f1f65c8f2b22865496
-  react-native-safe-area-context: 7e513d737b0b5c1d10bbe0e5fcc9f925a7be144c
+  react-native-safe-area-context: 9d7528d2e8fce82d20cb0b643c8be34a4ad57464
   react-native-slider: bb7eb4732940fab78217e1c096bb647d8b0d1cf3
   react-native-webview: 5095dd03fc98a529e44a6bb81aed21062b5f879e
   React-NativeModulesApple: 88433b6946778bea9c153e27b671de15411bf225
@@ -2530,10 +2530,10 @@ SPEC CHECKSUMS:
   RNDateTimePicker: e30677c15dfba25452b1434181970162115cc4fe
   RNFBApp: 2b2bb0f17eb6732e2e90d9c57bfde443cd7fc681
   RNFBMessaging: 4627e84e9e363953357dd122543e4223c49e6bc1
-  RNGestureHandler: 8b1080a6db0be82dbca18550d6212b885bfab6b2
-  RNReanimated: 6383cd0d805e48768b97bd65bcb1d06f0e69ab8e
+  RNGestureHandler: dcb1b1db024f3744b03af56d132f4f72c4c27195
+  RNReanimated: 505a98a0122d5e3bbeb0fb91e93dfb67d8112b84
   RNScreens: 790123c4a28783d80a342ce42e8c7381bed62db1
-  RNSVG: 8126581b369adf6a0004b6a6cab1a55e3002d5b0
+  RNSVG: 4aaeac3fdc7c5bc88ca801e228f62fb469be37e9
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   Yoga: afd04ff05ebe0121a00c468a8a3c8080221cb14c
 

--- a/src/constants/queryKeys.ts
+++ b/src/constants/queryKeys.ts
@@ -1,3 +1,5 @@
+import {getScheduleList} from '@/services/calendar';
+
 /**
  * Tanstack Query 중 useQuery / useSuspenseQuery 사용시 편의성을 위해 키와 함수를 한 군데가 모아두는 파일입니다.
  * 형식은 다음과 같습니다.
@@ -9,3 +11,10 @@
  * };
  * @author 홍규진
  */
+
+export const calendarQuery = (workspaceId: string) => {
+  return {
+    queryKey: ['calendar', {workspaceId}],
+    queryFn: () => getScheduleList(workspaceId),
+  };
+};

--- a/src/screens/calendar/components/AddScheduleSheet/index.style.ts
+++ b/src/screens/calendar/components/AddScheduleSheet/index.style.ts
@@ -42,7 +42,7 @@ export const Dropdown = styled.View`
   top: 100%;
   left: 0;
   right: 0;
-  background-color: ${({theme}) => theme.colors.background};
+  background-color: transparent;
   border-radius: 14px;
   z-index: 1;
   elevation: 5;
@@ -66,13 +66,13 @@ export const AlarmOptionText = styled.Text`
 
 const getCategoryColor = (category: string, theme: Theme) => {
   switch (category) {
-    case '회의':
+    case 'Meeting':
       return theme.colors.red;
-    case '발표':
+    case 'Presentation':
       return theme.colors.blue;
-    case '활동':
+    case 'Activity':
       return theme.colors.yellow;
-    case '공부':
+    case 'Study':
       return theme.colors.pink;
     default:
       return theme.colors.background;

--- a/src/screens/calendar/constants/calendar.ts
+++ b/src/screens/calendar/constants/calendar.ts
@@ -52,7 +52,12 @@ export const TYPE_COLORS: Record<string, string> = {
   활동: 'yellow',
   공부: 'pink',
 };
-export const TYPES: ScheduleType[] = ['회의', '발표', '활동', '공부'];
+export const TYPES: ScheduleType[] = [
+  'Meeting',
+  'Presentation',
+  'Activity',
+  'Study',
+];
 
 // 더미 일정 데이터
 export const DUMMY_SCHEDULES = [

--- a/src/screens/calendar/constants/calendar.ts
+++ b/src/screens/calendar/constants/calendar.ts
@@ -1,4 +1,4 @@
-import {ScheduleCategory} from '../types';
+import {ScheduleType} from '../types';
 // 한글 요일/월 설정
 import {LocaleConfig} from 'react-native-calendars';
 
@@ -46,54 +46,53 @@ LocaleConfig.locales['ko'] = {
 LocaleConfig.defaultLocale = 'ko';
 
 // 카테고리별 색상
-export const CATEGORY_COLORS: Record<string, string> = {
+export const TYPE_COLORS: Record<string, string> = {
   회의: 'red',
   발표: 'purple',
   활동: 'yellow',
   공부: 'pink',
 };
+export const TYPES: ScheduleType[] = ['회의', '발표', '활동', '공부'];
 
 // 더미 일정 데이터
 export const DUMMY_SCHEDULES = [
   {
-    id: '1',
-    category: '회의',
-    title: '팀 회의',
-    startDate: new Date('2024-12-08T10:00:00'),
-    endDate: new Date('2024-12-08T11:00:00'),
+    scheduleId: '1',
+    type: '회의',
+    scheduleTitle: '팀 회의',
+    startSchedule: new Date('2024-12-08T10:00:00'),
+    endSchedule: new Date('2024-12-08T11:00:00'),
     isAlarm: true,
-    memo: '주간 업무 공유',
+    scheduleDescription: '주간 업무 공유',
   },
   {
-    id: '2',
-    category: '공부',
-    title: 'React 공부',
-    startDate: new Date('2024-12-08T14:00:00'),
-    endDate: new Date('2024-12-08T16:00:00'),
+    scheduleId: '2',
+    type: '공부',
+    scheduleTitle: 'React 공부',
+    startSchedule: new Date('2024-12-08T14:00:00'),
+    endSchedule: new Date('2024-12-08T16:00:00'),
     isAlarm: false,
-    memo: '',
+    scheduleDescription: '',
   },
   {
-    id: '3',
-    category: '발표',
-    title: '프로젝트 발표',
-    startDate: new Date('2024-12-12T09:00:00'),
-    endDate: new Date('2024-12-12T10:00:00'),
+    scheduleId: '3',
+    type: '발표',
+    scheduleTitle: '프로젝트 발표',
+    startSchedule: new Date('2024-12-12T09:00:00'),
+    endSchedule: new Date('2024-12-12T10:00:00'),
     isAlarm: true,
-    memo: '',
+    scheduleDescription: '',
   },
   {
-    id: '4',
-    category: '활동',
-    title: '동아리 활동',
-    startDate: new Date('2024-12-19T18:00:00'),
-    endDate: new Date('2024-12-19T20:00:00'),
+    scheduleId: '4',
+    type: '활동',
+    scheduleTitle: '동아리 활동',
+    startSchedule: new Date('2024-12-19T18:00:00'),
+    endSchedule: new Date('2024-12-19T20:00:00'),
     isAlarm: false,
-    memo: '',
+    scheduleDescription: '',
   },
 ];
-
-export const CATEGORIES: ScheduleCategory[] = ['회의', '발표', '활동', '공부'];
 
 export const ALARM_OPTIONS = [
   {label: ' 5분 전', value: 5},

--- a/src/screens/calendar/hooks/useCalendar.ts
+++ b/src/screens/calendar/hooks/useCalendar.ts
@@ -23,7 +23,7 @@ export const useCalendar = () => {
   const [focusedDate, setFocusedDate] = useState<string | null>(null);
 
   // TODO-[규진] 워크스페이스 관련 로직 끝나면 이걸로 맞게 추가
-  const {data: scheduleListData} = useCalendarQuery('1');
+  // const {data: scheduleListData} = useCalendarQuery('1');
 
   // markedDates 생성
   const currentMarkedDates = useMemo(() => {
@@ -31,7 +31,7 @@ export const useCalendar = () => {
       string,
       {dots: {key: string; color: string}[]; selected?: boolean}
     > = {};
-    scheduleListData.forEach(schedule => {
+    DUMMY_SCHEDULES.forEach(schedule => {
       const dateStr = schedule.startSchedule.toISOString().split('T')[0];
       if (!marked[dateStr]) marked[dateStr] = {dots: []};
       marked[dateStr].dots.push({
@@ -45,7 +45,7 @@ export const useCalendar = () => {
       marked[focusedDate].selected = true;
     }
     return marked;
-  }, [focusedDate, scheduleListData]);
+  }, [focusedDate]);
 
   // filteredSchedules: focusedDate가 있으면 해당 날짜, 없으면 달
   const filteredSchedules = useMemo(() => {

--- a/src/screens/calendar/hooks/useCalendarQuery.ts
+++ b/src/screens/calendar/hooks/useCalendarQuery.ts
@@ -1,0 +1,20 @@
+import {calendarQuery} from '@/constants/queryKeys';
+import {useSuspenseQuery} from '@tanstack/react-query';
+
+/**
+ * 캘린더 일정 목록 조회 훅
+ * @param workspaceId 워크스페이스 ID
+ * @returns 캘린더 일정 목록
+ * @author 홍규진
+ */
+
+export const useCalendarQuery = (workspaceId: string) => {
+  const {data} = useSuspenseQuery({
+    queryKey: calendarQuery(workspaceId).queryKey,
+    queryFn: calendarQuery(workspaceId).queryFn,
+  });
+
+  return {
+    data,
+  };
+};

--- a/src/screens/calendar/hooks/useSchedule.ts
+++ b/src/screens/calendar/hooks/useSchedule.ts
@@ -1,19 +1,8 @@
 import {useState} from 'react';
-import {ScheduleCategory} from '../types';
+import {ScheduleType} from '../types';
 
-export interface Schedule {
-  id: string;
-  category: ScheduleCategory;
-  title: string;
-  startDate: Date;
-  endDate: Date;
-  isAlarm: boolean;
-  memo: string;
-}
-
-export const useSchedule = (selectedDate: string) => {
-  const [schedules, setSchedules] = useState<Schedule[]>([]);
-  const [category, setCategory] = useState<ScheduleCategory>('회의');
+export const useSchedule = () => {
+  const [category, setCategory] = useState<ScheduleType>('Meeting');
   const [title, setTitle] = useState('');
   const [startDate, setStartDate] = useState(new Date());
   const [endDate, setEndDate] = useState(new Date());
@@ -21,8 +10,7 @@ export const useSchedule = (selectedDate: string) => {
   const [memo, setMemo] = useState('');
   const [showCategoryDropdown, setShowCategoryDropdown] = useState(false);
 
-
-  const handleCategoryChange = (newCategory: ScheduleCategory) => {
+  const handleCategoryChange = (newCategory: ScheduleType) => {
     setCategory(newCategory);
     setShowCategoryDropdown(false);
   };
@@ -51,23 +39,8 @@ export const useSchedule = (selectedDate: string) => {
     setShowCategoryDropdown(prev => !prev);
   };
 
-  const addSchedule = () => {
-    const newSchedule: Schedule = {
-      id: Date.now().toString(),
-      category,
-      title,
-      startDate,
-      endDate,
-      isAlarm,
-      memo,
-    };
-
-    setSchedules(prev => [...prev, newSchedule]);
-    resetForm();
-  };
-
   const resetForm = () => {
-    setCategory('회의');
+    setCategory('Meeting');
     setTitle('');
     setStartDate(new Date());
     setEndDate(new Date());
@@ -76,16 +49,7 @@ export const useSchedule = (selectedDate: string) => {
     setShowCategoryDropdown(false);
   };
 
-  const filteredSchedules = schedules.filter(schedule => {
-    const scheduleDate = new Date(schedule.startDate)
-      .toISOString()
-      .split('T')[0];
-    return scheduleDate === selectedDate;
-  });
-
   return {
-    schedules,
-    filteredSchedules,
     category,
     title,
     startDate,
@@ -100,6 +64,6 @@ export const useSchedule = (selectedDate: string) => {
     handleToggleAlarm,
     handleMemoChange,
     toggleCategoryDropdown,
-    addSchedule,
+    resetForm,
   };
 };

--- a/src/screens/calendar/index.style.ts
+++ b/src/screens/calendar/index.style.ts
@@ -12,15 +12,17 @@ export const CalendarContainer = styled.View`
   overflow: hidden;
 `;
 
-export const ScheduleContainer = styled.View`
+export const ScheduleContainer = styled.ScrollView`
   flex: 1;
   padding: 16px;
   background-color: ${({theme}) => theme.colors.background};
+  position: relative;
 `;
 
 export const ScheduleTitle = styled.Text`
   ${({theme}) => theme.fonts.title4};
   color: ${({theme}) => theme.colors.textPrimary};
+  margin-left: 24px;
   margin-bottom: 12px;
 `;
 
@@ -37,11 +39,11 @@ export const NoScheduleText = styled.Text`
   margin-top: 24px;
 `;
 
-export const ScheduleItemContainer = styled.View<{category: string}>`
+export const ScheduleItemContainer = styled.View<{type: string}>`
   background-color: ${({theme}) => theme.colors.backgroundBase};
   border-left-width: 4px;
   border-left-color: ${props => {
-    switch (props.category) {
+    switch (props.type) {
       case '회의':
         return props.theme.colors.red;
       case '발표':

--- a/src/screens/calendar/index.tsx
+++ b/src/screens/calendar/index.tsx
@@ -1,4 +1,4 @@
-import React, {useMemo} from 'react';
+import React from 'react';
 import {Calendar} from 'react-native-calendars';
 import {useCalendar} from './hooks/useCalendar';
 import {
@@ -13,8 +13,7 @@ import {
   ScheduleMemo,
 } from './index.style';
 import {AddScheduleButton} from './components/AddScheduleButton';
-import {formatDateTime} from './utils/formatDate';
-import {CATEGORY_COLORS, DUMMY_SCHEDULES} from './constants/calendar';
+import {formatDateTime, getModeIcon} from './utils/formatDate';
 
 /**
  * 캘린더 페이지입니다.
@@ -26,81 +25,56 @@ import {CATEGORY_COLORS, DUMMY_SCHEDULES} from './constants/calendar';
 
 export const CalendarScreen = () => {
   const {
-    selectedDate,
-    setSelectedDate,
     handleOpenAddSchedule,
-    // currentMarkedDates,
     calendarTheme,
     calendarKey,
+    focusedDate,
+    handleDayPress,
+    handleMonthChange,
+    currentMarkedDates,
+    filteredSchedules,
   } = useCalendar();
-
-  // const {filteredSchedules} = useSchedule(selectedDate);
-
-  // markedDates 생성
-  const currentMarkedDatesMemo = useMemo(() => {
-    const marked: Record<
-      string,
-      {dots: {key: string; color: string}[]; selected?: boolean}
-    > = {};
-    DUMMY_SCHEDULES.forEach(schedule => {
-      const dateStr = schedule.startDate.toISOString().split('T')[0];
-      if (!marked[dateStr]) marked[dateStr] = {dots: []};
-      marked[dateStr].dots.push({
-        key: schedule.category,
-        color: CATEGORY_COLORS[schedule.category] || 'blue',
-      });
-    });
-    // 선택된 날짜 강조
-    if (selectedDate) {
-      if (!marked[selectedDate]) marked[selectedDate] = {dots: []};
-      marked[selectedDate].selected = true;
-    }
-    return marked;
-  }, [selectedDate]);
-
-  // 선택된 날짜의 일정만 필터링
-  const filteredSchedulesMemo = useMemo(
-    () =>
-      DUMMY_SCHEDULES.filter(
-        s => s.startDate.toISOString().split('T')[0] === selectedDate,
-      ),
-    [selectedDate],
-  );
 
   return (
     <Container>
       <CalendarContainer>
         <Calendar
           key={calendarKey}
-          onDayPress={day => setSelectedDate(day.dateString)}
+          onDayPress={handleDayPress}
+          onMonthChange={handleMonthChange}
           enableSwipeMonths={true}
           markingType="multi-dot"
-          markedDates={currentMarkedDatesMemo}
+          markedDates={currentMarkedDates}
           monthFormat="yyyy년 MM월"
           theme={calendarTheme}
         />
       </CalendarContainer>
+      <ScheduleTitle>
+        {getModeIcon(focusedDate ? 'day' : 'month')}
+        {focusedDate ? '이 날의 일정' : '이 달의 일정'}
+      </ScheduleTitle>
       <ScheduleContainer>
-        <ScheduleTitle>일정</ScheduleTitle>
-        {filteredSchedulesMemo.length > 0 ? (
-          filteredSchedulesMemo.map(schedule => (
+        {filteredSchedules.length > 0 ? (
+          filteredSchedules.map(schedule => (
             <ScheduleItemContainer
-              key={schedule.id}
-              category={schedule.category}>
+              key={schedule.scheduleId}
+              type={schedule.type || ''}>
               <ScheduleItemTime>
-                {formatDateTime(schedule.startDate)} ~{' '}
-                {formatDateTime(schedule.endDate)}
+                {formatDateTime(schedule.startSchedule)} ~{' '}
+                {formatDateTime(schedule.endSchedule)}
               </ScheduleItemTime>
-              <ScheduleItemTitle>{schedule.title}</ScheduleItemTitle>
+              <ScheduleItemTitle>{schedule.scheduleTitle}</ScheduleItemTitle>
               {/* <ScheduleItemMaker>{schedule.maker}</ScheduleItemMaker> */}
-              {schedule.memo && <ScheduleMemo>{schedule.memo}</ScheduleMemo>}
+              {schedule.scheduleDescription && (
+                <ScheduleMemo>{schedule.scheduleDescription}</ScheduleMemo>
+              )}
             </ScheduleItemContainer>
           ))
         ) : (
           <NoScheduleText>등록된 일정이 없습니다.</NoScheduleText>
         )}
-        <AddScheduleButton handleOpenAddSchedule={handleOpenAddSchedule} />
       </ScheduleContainer>
+      <AddScheduleButton handleOpenAddSchedule={handleOpenAddSchedule} />
     </Container>
   );
 };

--- a/src/screens/calendar/index.tsx
+++ b/src/screens/calendar/index.tsx
@@ -14,6 +14,7 @@ import {
 } from './index.style';
 import {AddScheduleButton} from './components/AddScheduleButton';
 import {formatDateTime, getModeIcon} from './utils/formatDate';
+// import {DUMMY_SCHEDULES} from './constants/calendar';
 
 /**
  * 캘린더 페이지입니다.

--- a/src/screens/calendar/types/index.ts
+++ b/src/screens/calendar/types/index.ts
@@ -1,15 +1,23 @@
 export interface Schedule {
-  id: string;
-  category: ScheduleCategory;
-  title: string;
-  startDate: Date;
-  endDate: Date;
+  scheduleId: string;
   isAlarm: boolean;
-  memo: string;
+  type: string;
+  scheduleWriter: string;
+  scheduleTitle: string;
+  startSchedule: Date;
+  endSchedule: Date;
+  startAlarm?: Date;
+  scheduleDescription?: string;
 }
 
-export type ScheduleCategory = '회의' | '발표' | '활동' | '공부';
-
+export type ScheduleType = 'Study' | 'Presentation' | 'Meeting' | 'Activity';
+// 타입 매핑 테이블
+export const TYPE_LABELS: Record<ScheduleType, string> = {
+  Study: '공부',
+  Presentation: '발표',
+  Meeting: '회의',
+  Activity: '활동',
+};
 export interface MarkedDates {
   [date: string]: {
     marked?: boolean;
@@ -18,6 +26,23 @@ export interface MarkedDates {
   };
 }
 
+// 타입 정의 (파일 상단에 위치시키는 것이 좋음)
+export type DayPressEventData = {
+  dateString: string;
+  day: number;
+  month: number;
+  year: number;
+  timestamp: number;
+};
+
+export type Month = {
+  dateString: string;
+  month: number;
+  year: number;
+  timestamp: number;
+};
+
+/* 캘린더 테마 */
 export interface CalendarTheme {
   arrowColor: string;
   backgroundColor: string;

--- a/src/screens/calendar/utils/formatDate.ts
+++ b/src/screens/calendar/utils/formatDate.ts
@@ -7,3 +7,48 @@ export const formatDateTime = (date: Date) => {
     minute: '2-digit',
   });
 };
+
+// '2025-03-03' → '2025-03'
+export function getMonth(dateStr: string | Date) {
+  const d = typeof dateStr === 'string' ? new Date(dateStr) : dateStr;
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}`;
+}
+
+// 주의 시작/끝 구하기
+export function getWeekRange(dateStr: string) {
+  const d = new Date(dateStr);
+  const day = d.getDay();
+  const start = new Date(d);
+  start.setDate(d.getDate() - day);
+  const end = new Date(d);
+  end.setDate(d.getDate() + (6 - day));
+  return {
+    start: start.toISOString().split('T')[0],
+    end: end.toISOString().split('T')[0],
+  };
+}
+
+// 같은 주인지 판별
+export function isSameWeek(date: Date, start: string, end: string) {
+  const d = date.toISOString().split('T')[0];
+  return d >= start && d <= end;
+}
+
+// 같은 달인지 판별
+export function isSameMonth(date: Date, month: string) {
+  return getMonth(date) === month;
+}
+
+// 모드에 따른 아이콘 반환
+export const getModeIcon = (mode: string) => {
+  switch (mode) {
+    case 'month':
+      return '📅'; // 또는 <MonthIcon />
+    case 'week':
+      return '🗂️'; // 또는 <WeekIcon />
+    case 'day':
+      return '📝'; // 또는 <DayIcon />
+    default:
+      return '';
+  }
+};

--- a/src/services/calendar/index.ts
+++ b/src/services/calendar/index.ts
@@ -1,0 +1,28 @@
+import {privateServerInstance} from '../api/axios';
+import {TGetResponse} from '../api/type';
+import {TGetScheduleResponse, TPostScheduleRequest} from './types';
+/**
+ * 일정 생성 API 호출 함수입니다.
+ * @author 홍규진
+ */
+export const createSchedule = async (
+  request: TPostScheduleRequest,
+): Promise<void> => {
+  await privateServerInstance.post<TGetResponse<void>>(
+    `/api/v1/schedule/${request.workspaceId}`,
+    request,
+  );
+};
+
+/**
+ * 일정 목록 조회 API 호출 함수입니다.
+ * @author 홍규진
+ */
+export const getScheduleList = async (
+  workspaceId: string,
+): Promise<TGetScheduleResponse> => {
+  const response = await privateServerInstance.get<
+    TGetResponse<TGetScheduleResponse>
+  >(`/api/v1/schedule/${workspaceId}`);
+  return response.data.data;
+};

--- a/src/services/calendar/types.ts
+++ b/src/services/calendar/types.ts
@@ -1,0 +1,16 @@
+import {Schedule} from '@/screens/calendar/types';
+
+/**
+ * 일정 생성 요청 타입
+ */
+export type TPostScheduleRequest = Omit<
+  Schedule,
+  'scheduleId' | 'scheduleWriter'
+> & {
+  workspaceId: string;
+};
+
+/**
+ * 일정 조회 응답 타입
+ */
+export type TGetScheduleResponse = Schedule[];


### PR DESCRIPTION
## 관련 이슈

- Resolves : #63 
 
## 작업 사항
![캘린더 개선 후](https://github.com/user-attachments/assets/5d75a72e-e873-4c94-8cb2-0b270d9bb607)

기존의 캘린더는 selectedDay 에 한해서만 일정을 제공해줬었습니다. 이제는 selectedDay에 포함된 월을 기준으로 모든 일정을 최초 제공해주고, 이후에 터치에 따라서, selectedDay 로 수정합니다. 기존의 백엔드 단에서 통일되어있지 않았던 enum 명명법을 통일하고 타입을 정의합니다. (일정을 정할 때 선택하는 카테고리)


## 참고 사항
@park20011029 백엔드 작업 완료시에 연락 부탁드립니다,,,!