### PR TITLE
Feature/#67 - 워크스페이스 멤버 추가, 리스트, 멤버 설정 기능 구현

### DIFF
--- a/src/constants/mutationKeys.ts
+++ b/src/constants/mutationKeys.ts
@@ -9,7 +9,7 @@ import {
   TDeleteMemberRequest,
   TUpdateMemberRequest,
 } from '@/services/member/types';
-import {deleteMember, updateMember} from '@/services/member';
+import {addMember, deleteMember, updateMember} from '@/services/member';
 
 /**
  * Tanstack Query 중 useMutation 사용시 편의성을 위해 키와 함수를 한 군데가 모아두는 파일입니다.
@@ -62,6 +62,19 @@ export const finalSubmitRecordMutationKey = () => {
     mutationSuccessKey: [],
     mutationFn: (request: TPostFinalTemplateContent) =>
       finalSubmitRecord(request),
+  };
+};
+
+/**
+ * 멤버 추가 뮤테이션 키
+ * @author 홍규진
+ */
+export const memberAddMutationKey = () => {
+  return {
+    mutationKey: ['memberAdd'],
+    mutationSuccessKey: [...memberListQuery().queryKey],
+    mutationFn: (workspaceId: string, email: string) =>
+      addMember(workspaceId, email),
   };
 };
 

--- a/src/screens/index.ts
+++ b/src/screens/index.ts
@@ -16,4 +16,7 @@ export * from './calendar';
 export * from './meeting';
 export * from './my-page';
 export * from './write';
-export * from './postDetail';
+export * from './post-detail';
+export * from './member';
+export * from './init-workspace';
+export * from './create-workspace';

--- a/src/screens/member/components/AddMemberModal/index.style.ts
+++ b/src/screens/member/components/AddMemberModal/index.style.ts
@@ -1,0 +1,42 @@
+import styled from '@emotion/native';
+
+export const ModalContainer = styled.View`
+  background-color: ${({theme}) => theme.colors.background};
+  border-radius: 20px;
+  padding: 24px 24px 24px 0px;
+  align-items: center;
+`;
+
+export const InputRow = styled.View`
+  width: 100%;
+  flex-direction: row;
+  align-items: center;
+  margin-bottom: 24px;
+`;
+
+export const EmailInput = styled.TextInput`
+  flex: 1;
+  height: 40px;
+  background-color: ${({theme}) => theme.colors.backgroundBase};
+  border-radius: 20px;
+  padding: 0 16px;
+  font-size: 16px;
+  color: ${({theme}) => theme.colors.textPrimary};
+`;
+
+export const AddButton = styled.TouchableOpacity<{disabled?: boolean}>`
+  margin-left: 8px;
+  background-color: ${({theme, disabled}) =>
+    disabled ? theme.colors.textDisabled : theme.colors.blue};
+  border-radius: 20px;
+  padding: 0 18px;
+  height: 40px;
+  justify-content: center;
+  align-items: center;
+`;
+
+export const AddButtonText = styled.Text`
+  color: #fff;
+  font-size: 16px;
+  font-weight: 600;
+`;

--- a/src/screens/member/components/AddMemberModal/index.tsx
+++ b/src/screens/member/components/AddMemberModal/index.tsx
@@ -1,0 +1,37 @@
+import React, {useState} from 'react';
+import {
+  ModalContainer,
+  InputRow,
+  EmailInput,
+  AddButton,
+  AddButtonText,
+} from './index.style';
+import {useThemeColors} from '@/contexts/theme/ThemeContext';
+
+interface AddMemberModalProps {
+  onAdd: (email: string) => void;
+}
+
+export const AddMemberModal: React.FC<AddMemberModalProps> = ({onAdd}) => {
+  const [email, setEmail] = useState('');
+  const {textDisabled} = useThemeColors();
+  const handleAdd = () => {
+    onAdd(email);
+    setEmail('');
+  };
+  return (
+    <ModalContainer>
+      <InputRow>
+        <EmailInput
+          placeholder="이메일을 입력하세요"
+          value={email}
+          placeholderTextColor={textDisabled}
+          onChangeText={setEmail}
+        />
+        <AddButton onPress={handleAdd} disabled={!email}>
+          <AddButtonText>추가</AddButtonText>
+        </AddButton>
+      </InputRow>
+    </ModalContainer>
+  );
+};

--- a/src/screens/member/components/MemberSettingModal/index.style.ts
+++ b/src/screens/member/components/MemberSettingModal/index.style.ts
@@ -1,0 +1,57 @@
+import styled from '@emotion/native';
+
+export const ModalContainer = styled.View`
+  background-color: ${({theme}) => theme.colors.background};
+  border-radius: 20px;
+  padding: 0px 24px 24px 24px;
+  align-items: center;
+`;
+
+export const Title = styled.Text`
+  ${({theme}) => theme.fonts.title2};
+  margin-bottom: 24px;
+  color: ${({theme}) => theme.colors.textPrimary};
+`;
+
+export const ProfileImage = styled.Image`
+  width: 80px;
+  height: 80px;
+  border-radius: 40px;
+  background-color: ${({theme}) => theme.colors.textDisabled};
+  margin-bottom: 16px;
+`;
+
+export const MemberName = styled.Text`
+  ${({theme}) => theme.fonts.text2};
+  margin-bottom: 32px;
+  color: ${({theme}) => theme.colors.textPrimary};
+`;
+
+export const Row = styled.View`
+  width: 100%;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 18px;
+`;
+
+export const Label = styled.Text`
+  ${({theme}) => theme.fonts.text3};
+  color: ${({theme}) => theme.colors.textPrimary};
+`;
+
+export const Value = styled.Text`
+  ${({theme}) => theme.fonts.text3};
+  color: ${({theme}) => theme.colors.textPrimary};
+`;
+
+export const SwitchRow = styled(Row)`
+  margin-bottom: 28px;
+`;
+
+export const DangerText = styled.Text`
+  color: ${({theme}) => theme.colors.red};
+  text-align: center;
+  ${({theme}) => theme.fonts.text3};
+  margin-bottom: 24px;
+`;

--- a/src/screens/member/components/MemberSettingModal/index.tsx
+++ b/src/screens/member/components/MemberSettingModal/index.tsx
@@ -1,0 +1,48 @@
+import React, {useState} from 'react';
+import {
+  ModalContainer,
+  Title,
+  ProfileImage,
+  MemberName,
+  Label,
+  SwitchRow,
+  DangerText,
+} from './index.style';
+import {Switch} from 'react-native';
+import {Member} from '../../types';
+import defaultProfileImage from '@/assets/images/png/defaultProfile.png';
+import {useDeleteMemberMutation} from '../../hooks/useMemberMutation';
+
+export const MemberSettingModal: React.FC<
+  Member & {onAdminChange: (isAdmin: boolean) => void}
+> = ({memberId, memberRole, memberName, memberImage, onAdminChange}) => {
+  const [admin, setAdmin] = useState(memberRole === 'eAdmin');
+  const {mutateAsync: deleteMember} = useDeleteMemberMutation();
+  const handleSwitch = (value: boolean) => {
+    setAdmin(value);
+    onAdminChange(value);
+  };
+
+  return (
+    <ModalContainer>
+      <Title>멤버 관리</Title>
+      <ProfileImage
+        source={memberImage ? {uri: memberImage} : defaultProfileImage}
+      />
+      <MemberName>{memberName}</MemberName>
+
+      <SwitchRow>
+        <Label>관리자 권한 부여</Label>
+        <Switch value={admin} onValueChange={handleSwitch} />
+      </SwitchRow>
+
+      <DangerText
+        onPress={() => {
+          //TODO-[규진] 워크스페이스 ID 동적으로 바꾸기
+          deleteMember({workspaceId: '1', memberId});
+        }}>
+        강제 탈퇴
+      </DangerText>
+    </ModalContainer>
+  );
+};

--- a/src/screens/member/constants/mockData.ts
+++ b/src/screens/member/constants/mockData.ts
@@ -1,0 +1,28 @@
+import {Member} from '../types';
+
+export const mockMemberList: Member[] = [
+  {
+    memberId: 1,
+    memberRole: 'eAdmin',
+    memberName: 'park',
+    memberImage: '1',
+  },
+  {
+    memberId: 2,
+    memberRole: 'eMember',
+    memberName: 'hong',
+    memberImage: '1',
+  },
+  {
+    memberId: 3,
+    memberRole: 'eMember',
+    memberName: 'eum',
+    memberImage: '1',
+  },
+  {
+    memberId: 8,
+    memberRole: 'eMember',
+    memberName: 'jung',
+    memberImage: '1',
+  },
+];

--- a/src/screens/member/hooks/useMemberListQuery.ts
+++ b/src/screens/member/hooks/useMemberListQuery.ts
@@ -1,0 +1,15 @@
+import {useSuspenseQuery} from '@tanstack/react-query';
+import {getMemberList} from '@/services/member';
+
+/**
+ * 멤버 목록 조회 쿼리 훅 입니다.
+ * @author 홍규진
+ */
+export const useMemberListQuery = (workspaceId: string) => {
+  const {data, isLoading, error, refetch} = useSuspenseQuery({
+    queryKey: ['memberList', {workspaceId}],
+    queryFn: () => getMemberList(workspaceId),
+  });
+
+  return {data, isLoading, error, refetch};
+};

--- a/src/screens/member/hooks/useMemberMutation.ts
+++ b/src/screens/member/hooks/useMemberMutation.ts
@@ -1,0 +1,86 @@
+import {useMutation, useQueryClient} from '@tanstack/react-query';
+import {
+  TDeleteMemberRequest,
+  TUpdateMemberRequest,
+} from '@/services/member/types';
+import {useModal} from '@/contexts/modal/ModalContext';
+import {
+  memberDeleteMutationKey,
+  memberUpdateMutationKey,
+  memberAddMutationKey,
+} from '@/constants/mutationKeys';
+
+/**
+ * 멤버 추가 뮤테이션 훅입니다.
+ * 멤버 추가 요청을 처리합니다.
+ * 멤버 추가시에 멤버 목록 조회 캐시를 무효화합니다.
+ * @returns 멤버 추가 뮤테이션 함수
+ * @author 홍규진
+ */
+export const useAddMemberMutation = () => {
+  const queryClient = useQueryClient();
+  const {mutateAsync} = useMutation({
+    mutationKey: memberAddMutationKey().mutationKey,
+    mutationFn: ({workspaceId, email}: {workspaceId: string; email: string}) =>
+      memberAddMutationKey().mutationFn(workspaceId, email),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: memberAddMutationKey().mutationSuccessKey,
+      });
+    },
+  });
+  return {
+    mutateAsync,
+  };
+};
+
+/**
+ * 멤버 권한 변경 뮤테이션 훅입니다.
+ * 멤버 권한 변경 요청을 처리합니다.
+ * 멤버 권한 변경시에 멤버 목록 조회 캐시를 무효화합니다.
+ * @returns 멤버 권한 변경 뮤테이션 함수
+ * @author 홍규진
+ */
+export const useMemberMutation = () => {
+  const queryClient = useQueryClient();
+  const {mutateAsync} = useMutation({
+    mutationKey: memberUpdateMutationKey().mutationKey,
+    mutationFn: (member: TUpdateMemberRequest) =>
+      memberUpdateMutationKey().mutationFn(member),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: memberUpdateMutationKey().mutationSuccessKey,
+      });
+    },
+  });
+
+  return {
+    mutateAsync,
+  };
+};
+
+/**
+ * 멤버 강제 탈퇴 뮤테이션 훅입니다.
+ * 멤버 강제 탈퇴 요청을 처리합니다.
+ * 멤버 강제 탈퇴시에 멤버 목록 조회 캐시를 무효화합니다.
+ * @returns 멤버 강제 탈퇴 뮤테이션 함수
+ * @author 홍규진
+ */
+export const useDeleteMemberMutation = () => {
+  const queryClient = useQueryClient();
+  const {setIsOpen} = useModal();
+  const {mutateAsync} = useMutation({
+    mutationKey: memberDeleteMutationKey().mutationKey,
+    mutationFn: ({workspaceId, memberId}: TDeleteMemberRequest) =>
+      memberDeleteMutationKey().mutationFn({workspaceId, memberId}),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: memberDeleteMutationKey().mutationSuccessKey,
+      });
+      setIsOpen(false);
+    },
+  });
+  return {
+    mutateAsync,
+  };
+};

--- a/src/screens/member/index.style.ts
+++ b/src/screens/member/index.style.ts
@@ -1,0 +1,36 @@
+import styled from '@emotion/native';
+
+export const Container = styled.ScrollView`
+  flex: 1;
+  background-color: ${({theme}) => theme.colors.background};
+`;
+
+export const TopBarContainer = styled.View`
+  padding: 20px 20px 0 20px;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+`;
+export const SearchBarWrapper = styled.View`
+  flex: 1;
+  align-items: center;
+`;
+export const PlusButtonWrapper = styled.TouchableOpacity`
+  background-color: ${({theme}) => theme.colors.blue};
+  border-radius: 50px;
+  padding: 16px;
+`;
+
+export const MemberList = styled.ScrollView`
+  flex: 1;
+  padding: 0 20px;
+`;
+
+export const MemberItem = styled.View`
+  flex-direction: row;
+  align-items: center;
+  background-color: ${({theme}) => theme.colors.backgroundElevated};
+  border-radius: 16px;
+  margin-bottom: 12px;
+  padding: 16px;
+`;

--- a/src/screens/member/index.tsx
+++ b/src/screens/member/index.tsx
@@ -1,0 +1,95 @@
+import React, {useState} from 'react';
+import {
+  Container,
+  SearchBarWrapper,
+  MemberList,
+  MemberItem,
+  PlusButtonWrapper,
+  TopBarContainer,
+} from './index.style';
+import {MemberProfile} from '@/components/MemberProfile';
+import {SearchBar} from '@/components/SearchBar';
+import {useMemberListQuery} from './hooks/useMemberListQuery';
+import {RefreshControl} from 'react-native';
+import {useWorkspace} from '@/contexts/workspace/WorkspaceContenxt';
+import {PlusIcon} from '@/assets/images/svg/common';
+import {useTheme} from '@/contexts/theme/ThemeContext';
+import {useModal} from '@/contexts/modal/ModalContext';
+import {AddMemberModal} from './components/AddMemberModal';
+import CommonModal from '@/components/CommonModal';
+import {useAddMemberMutation} from './hooks/useMemberMutation';
+
+export const MemberScreen = () => {
+  const theme = useTheme();
+  const [search, setSearch] = useState('');
+  const {workspaceId} = useWorkspace();
+  const {data: memberList, refetch: refetchMemberList} = useMemberListQuery(
+    workspaceId ?? '-1',
+  );
+  const {mutateAsync: addMember} = useAddMemberMutation();
+  const {setIsOpen, setModalContent} = useModal();
+  const [refreshing, setRefreshing] = useState(false);
+
+  const onRefresh = React.useCallback(async () => {
+    setRefreshing(true);
+    await refetchMemberList();
+    setRefreshing(false);
+  }, [refetchMemberList]);
+  const filtered =
+    search === ''
+      ? memberList
+      : memberList.filter(m => m.memberName.includes(search));
+
+  return (
+    <Container
+      refreshControl={
+        <RefreshControl refreshing={refreshing} onRefresh={onRefresh} />
+      }>
+      <TopBarContainer>
+        <SearchBarWrapper>
+          <SearchBar
+            isDebouncing={true}
+            onSearchSubmit={setSearch}
+            placeholder="이름으로 검색하세요"
+          />
+        </SearchBarWrapper>
+        <PlusButtonWrapper
+          onPress={() => {
+            setIsOpen(true);
+            setModalContent(
+              <CommonModal
+                type="default"
+                title="멤버 추가"
+                children={
+                  <AddMemberModal
+                    onAdd={email => {
+                      addMember({
+                        workspaceId: workspaceId ?? '-1',
+                        email,
+                      });
+                    }}
+                  />
+                }
+              />,
+            );
+          }}>
+          <PlusIcon fill={theme.colors.white} />
+        </PlusButtonWrapper>
+      </TopBarContainer>
+
+      <MemberList>
+        {filtered.map(member => (
+          <MemberItem key={member.memberId}>
+            <MemberProfile
+              memberId={Number(member.memberId)}
+              memberRole={member.memberRole}
+              memberName={member.memberName}
+              memberImage={member.memberImage}
+              isCurrentUserManager={true}
+            />
+          </MemberItem>
+        ))}
+      </MemberList>
+    </Container>
+  );
+};

--- a/src/screens/member/types/index.ts
+++ b/src/screens/member/types/index.ts
@@ -1,0 +1,8 @@
+export type MemberRole = 'eAdmin' | 'eMember';
+
+export type Member = {
+  memberId: number;
+  memberRole: MemberRole;
+  memberName: string;
+  memberImage: string;
+};

--- a/src/services/member/index.ts
+++ b/src/services/member/index.ts
@@ -1,0 +1,63 @@
+import {privateServerInstance} from '@/services/api/axios';
+
+import {TGetMemberListResponse, TUpdateMemberRequest} from './types';
+import {TGetResponse} from '../api/type';
+
+/**
+ * 멤버 목록 조회 API 호출 함수입니다.
+ * @returns 멤버 목록
+ * @author 홍규진
+ */
+export async function getMemberList(workspaceId: string) {
+  const response = await privateServerInstance.get<
+    TGetResponse<TGetMemberListResponse>
+  >(`/api/v1/members/${workspaceId}`);
+  return response.data.data.memberList;
+}
+
+/**
+ * 멤버 추가 API 호출 함수입니다.
+ * @param workspaceId 워크스페이스 ID
+ * @param email 멤버 이메일
+ * @returns 멤버 추가 응답 데이터
+ * @author 홍규진
+ */
+export async function addMember(workspaceId: string, email: string) {
+  await privateServerInstance.post<TGetResponse<void>>(
+    `/api/v1/members/${workspaceId}`,
+    {email},
+  );
+}
+
+/**
+ * 멤버 권한 변경 API 호출 함수입니다.
+ * @param workspaceId 워크스페이스 ID
+ * @param memberId 멤버 ID
+ * @param member 멤버 권한 변경 요청 타입
+ * @returns 멤버 권한 변경 응답 데이터
+ * @author 홍규진
+ */
+export async function updateMember(
+  workspaceId: string,
+  member: TUpdateMemberRequest,
+) {
+  const response = await privateServerInstance.put<TGetResponse<void>>(
+    `/api/v1/members/${workspaceId}/${member.memberId}`,
+    member,
+  );
+  return response.data.data;
+}
+
+/**
+ * 멤버 강퇴 API 호출 함수입니다.
+ * @param workspaceId 워크스페이스 ID
+ * @param memberId 멤버 ID
+ * @returns 멤버 강퇴 응답 데이터
+ * @author 홍규진
+ */
+export async function deleteMember(workspaceId: string, memberId: number) {
+  const response = await privateServerInstance.delete<TGetResponse<boolean>>(
+    `/api/v1/members/${workspaceId}/${memberId}`,
+  );
+  return response.data.data;
+}

--- a/src/services/member/types.ts
+++ b/src/services/member/types.ts
@@ -1,0 +1,32 @@
+import {Member, MemberRole} from '@/screens/member/types';
+
+/**
+ * 멤버 목록 조회 응답 타입
+ * @author 홍규진
+ */
+export type TGetMemberListResponse = {
+  memberList: Member[];
+};
+
+/**
+ * 멤버 추가 요청 타입
+ * @author 홍규진
+ */
+export type TAddMemberRequest = {
+  email: string;
+};
+
+/**
+ * 멤버 권한 변경 요청 타입
+ * TODO-[규진] 명세서 완료되고 나서 수정 필요
+ * @author 홍규진
+ */
+export type TUpdateMemberRequest = {
+  memberId: number;
+  memberRole: MemberRole;
+};
+
+export type TDeleteMemberRequest = {
+  workspaceId: string;
+  memberId: number;
+};


### PR DESCRIPTION
## 관련 이슈

- Resolves : #67 
 
## 작업 사항
![Simulator Screen Recording - Poppin_Simulator - 2025-05-24 at 23 58 11](https://github.com/user-attachments/assets/55d24aa1-dae9-469f-92cd-f4fb9937fac9)


- Mutation은 작업, 작업 성공 후의 무효화 키를 Contants 의 MutationKey 에서 관리합니다.
- 따라서 성공시 무효화 할 쿼리 키는 memberListQuery 의 키입니다.
- 다음과 같은 방식으로 통일성 있게 Mutation을 구현합니다.

```tsx

/**
 * 멤버 추가 뮤테이션 키
 * @author 홍규진
 */
export const memberAddMutationKey = () => {
  return {
    mutationKey: ['memberAdd'],
    mutationSuccessKey: [...memberListQuery().queryKey],
    mutationFn: (workspaceId: string, email: string) =>
      addMember(workspaceId, email),
  };
};
```

## 참고 사항
- 멤버 추방시 이를 경고해주는 모달이 추가적으로 필요해보이긴 합니다.
- 디자인 상에서 멤버 모달에서 방문 횟수나, 작성 게시글 수가 불필요하다고 나온 논의 결과에 따라 제거했습니다.