### PR TITLE
Feature/#77 - ContextAPI 에서 jotai로 상태관리 마이그레이션 

### DIFF
--- a/src/components/FilePreview/index.tsx
+++ b/src/components/FilePreview/index.tsx
@@ -17,13 +17,15 @@ import {Shadow} from 'react-native-shadow-2';
 import {useThemeColors} from '@/contexts/theme/ThemeContext';
 import {OptionsBox} from '@/components/OptionsBox';
 import {View} from 'react-native';
-import {useWorkspace} from '@/hooks/useWorkspace';
+
 import {
   useDeleteFileMutation,
   useRenameFileMutation,
 } from '@/screens/file/hooks/uesFileMutation';
 import {useModal} from '@/contexts/modal/ModalContext';
 import {CommonModal} from '../CommonModal';
+import {useAtom} from 'jotai';
+import {workspaceState} from '@/atoms/workspace';
 
 /**
  * 자료 관리 페이지에 사용될 파일 프리뷰 컴포넌트 입니다.
@@ -35,7 +37,8 @@ import {CommonModal} from '../CommonModal';
 
 export const FilePreview = (file: FileData) => {
   const {blue, textDisabled, shadow, red, textPrimary} = useThemeColors();
-  const {workspace: workspaceInfo} = useWorkspace();
+  const [workspace] = useAtom(workspaceState);
+  console.log('workspace', workspace);
   const [isOptionsVisible, setIsOptionsVisible] = useState(false);
   const {mutate: renameFileMutation} = useRenameFileMutation();
   const {mutate: deleteFileMutation} = useDeleteFileMutation();
@@ -50,7 +53,7 @@ export const FilePreview = (file: FileData) => {
 
   const FormatIcon = file.docuementType === 'mp3' ? AudioFormat : DocFormat;
 
-  const MenuIcon = workspaceInfo.isAdmin ? MoreIcon : DownLoadIcon;
+  const MenuIcon = workspace.isAdmin ? MoreIcon : DownLoadIcon;
 
   const handleMenuPress = () => {
     menuRef.current?.measureInWindow((x, y, width, height) => {

--- a/src/components/FolderPreview/index.tsx
+++ b/src/components/FolderPreview/index.tsx
@@ -20,7 +20,8 @@ import {
   useDeleteDirectoryMutation,
   useRenameDirectoryMutation,
 } from '@/screens/file/hooks/uesFileMutation';
-import {useWorkspace} from '@/hooks/useWorkspace';
+import {useAtom} from 'jotai';
+import {workspaceState} from '@/atoms/workspace';
 
 export type FolderPreviewProps = {
   folder: FolderData;
@@ -38,7 +39,7 @@ export const FolderPreview = ({folder, isAdmin}: FolderPreviewProps) => {
     height: 0,
   });
   const menuRef = useRef<View>(null);
-  const {workspaceId} = useWorkspace();
+  const [workspace] = useAtom(workspaceState);
   const {mutate: patchDirectoryMutation} = useRenameDirectoryMutation();
   const {mutate: deleteDirectoryMutation} = useDeleteDirectoryMutation();
   const handleMenuPress = () => {
@@ -62,7 +63,7 @@ export const FolderPreview = ({folder, isAdmin}: FolderPreviewProps) => {
             inputPlaceholder="변경할 폴더 이름을 입력하세요"
             onConfirm={inputValue => {
               patchDirectoryMutation({
-                workspaceId: workspaceId!,
+                workspaceId: workspace.workspaceId,
                 dirId: folder.dirId,
                 directoryName: inputValue!,
               });

--- a/src/components/Header/index.style.ts
+++ b/src/components/Header/index.style.ts
@@ -89,7 +89,8 @@ export const IconTwo = styled(IconWrapper)`
 
 // 세 번째 아이콘 (맨 앞)
 export const IconThree = styled(IconWrapper)`
-  background-color: ${({theme}) => theme.colors.blue};
+  background-color: ${({theme}) => theme.colors.background};
+  border: 1px solid ${({theme}) => theme.colors.divider};
   z-index: 3;
   transform: translateX(4px);
   border-radius: 12px;

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -63,7 +63,7 @@ export const Header: React.FC = () => {
       </LeftContainer>
       <RightContainer>
         <GDLogoContainer onPress={handleWorkSpacePress}>
-          {workspaceList.length > 0 ? (
+          {workspaceList && workspaceList.length > 0 ? (
             <StackedIconsContainer>
               {workspaceList.length >= 3 && (
                 <IconOne onPress={handleWorkSpacePress}>

--- a/src/components/Header/useHeader.ts
+++ b/src/components/Header/useHeader.ts
@@ -3,7 +3,7 @@ import {useCallback} from 'react';
 import {useTheme} from '@/contexts/theme/ThemeContext';
 import {useWorkspaceListQuery} from '@/screens/home/hooks/useWorkspaceQuery';
 import useTypeSafeNavigation from '@/hooks/useTypeSafeNavigaion';
-import {useWorkspaceBottomSheet} from '@/hooks/useWorkspace';
+import {useWorkspaceBottomSheet} from '@/hooks/useWorkspaceBottomSheet';
 /**
  * 헤더 컴포넌트에 필요한 로직을 작성합니다.
  * 관심사 분리를 위해서, 헤더 컴포넌트에 필요한 로직들만 분리합니다.
@@ -39,6 +39,6 @@ export const useHeader = () => {
     handleWorkSpacePress,
     handleLogoPress,
     handleDarkLightLogoPress,
-    workspaceList: data.workspaceList,
+    workspaceList: data?.workspaceList,
   };
 };

--- a/src/components/MemberProfile/index.tsx
+++ b/src/components/MemberProfile/index.tsx
@@ -20,7 +20,8 @@ import {
   useDeleteMemberMutation,
   useModifyMemberRoleMutation,
 } from '@/screens/member/hooks/useMemberMutation';
-import {useWorkspace} from '@/hooks/useWorkspace';
+import {useAtom} from 'jotai';
+import {workspaceState} from '@/atoms/workspace';
 
 /**
  * 멤버 페이지 혹은 멤버 추가 모달에 보여지는 멤버 프로필 컴포넌트입니다.
@@ -53,7 +54,7 @@ export const MemberProfile: React.FC<MemberProfileProps> = ({
   const {setIsOpen, setModalContent} = useModal();
   const {mutateAsync: deleteMember} = useDeleteMemberMutation();
   const {mutateAsync: modifyMemberRole} = useModifyMemberRoleMutation();
-  const {workspaceId} = useWorkspace();
+  const [workspace] = useAtom(workspaceState);
 
   const handleSettingPress = () => {
     setModalContent(
@@ -68,7 +69,7 @@ export const MemberProfile: React.FC<MemberProfileProps> = ({
             memberImage={memberImage}
             onAdminChange={setIsAdmin}
             onDelete={() => {
-              deleteMember({workspaceId: workspaceId!, memberId});
+              deleteMember({workspaceId: workspace.workspaceId, memberId});
             }}
           />
         }

--- a/src/components/WorkspaceBottomSheet/index.tsx
+++ b/src/components/WorkspaceBottomSheet/index.tsx
@@ -16,7 +16,7 @@ import {
 } from '@/services/workspace/types';
 
 interface WorkspaceBottomSheetProps {
-  workspaceList: TGetWorkspaceListResponse;
+  workspaceList?: TGetWorkspaceListResponse;
   onSelect: (workspace: TWorkspace) => void;
   onAdd: () => void;
 }
@@ -29,7 +29,7 @@ export const WorkspaceBottomSheet: React.FC<WorkspaceBottomSheetProps> = ({
   return (
     <Container>
       <Title>워크스페이스 목록</Title>
-      {workspaceList.workspaceList.map(ws => (
+      {workspaceList?.workspaceList.map(ws => (
         <WorkspaceItem key={ws.workspaceId} onPress={() => onSelect(ws)}>
           <TitleRow>
             <WorkspaceTitle>{ws.workspaceName}</WorkspaceTitle>

--- a/src/constants/mutationKeys.ts
+++ b/src/constants/mutationKeys.ts
@@ -1,6 +1,13 @@
-import {TCreateWorkspaceRequest} from '@/services/workspace/types';
-import {memberListQuery, workspaceListQuery} from './queryKeys';
-import {createWorkspace} from '@/services/workspace';
+import {
+  TCreateWorkspaceRequest,
+  TEditWorkspaceRequest,
+} from '@/services/workspace/types';
+import {memberListQuery, workspaceListQuery, workspaceQuery} from './queryKeys';
+import {
+  createWorkspace,
+  deleteWorkspace,
+  editWorkspace,
+} from '@/services/workspace';
 import {TPostSubmitRecordRequest} from '@/services/meeting/types';
 import {submitRecord} from '@/services/meeting';
 import {TPostFinalTemplateContent} from '@/services/meeting/types';
@@ -59,6 +66,33 @@ export const createWorkspaceMutationKey = () => {
     mutationSuccessKey: [...workspaceListQuery().queryKey],
     mutationFn: (workspace: TCreateWorkspaceRequest) =>
       createWorkspace(workspace),
+  };
+};
+
+/**
+ * 워크스페이스 수정 뮤테이션 키
+ * @author 홍규진
+ */
+export const editWorkspaceMutationKey = (workspaceId: string) => {
+  return {
+    mutationKey: ['editWorkspace'],
+    mutationSuccessKey: [
+      ...workspaceQuery(workspaceId).queryKey,
+      ...workspaceListQuery().queryKey,
+    ],
+    mutationFn: (workspace: TEditWorkspaceRequest) => editWorkspace(workspace),
+  };
+};
+
+/**
+ * 워크스페이스 삭제 뮤테이션 키
+ * @author 홍규진
+ */
+export const deleteWorkspaceMutationKey = () => {
+  return {
+    mutationKey: ['deleteWorkspace'],
+    mutationSuccessKey: [...workspaceListQuery().queryKey],
+    mutationFn: (workspaceId: string) => deleteWorkspace(workspaceId),
   };
 };
 

--- a/src/hooks/useWorkspaceBottomSheet.tsx
+++ b/src/hooks/useWorkspaceBottomSheet.tsx
@@ -1,5 +1,4 @@
 import {useAtom} from 'jotai';
-import {useEffect} from 'react';
 
 import {useBottomSheet} from '@/contexts/bottomSheet/BottomSheetContext';
 import {useWorkspaceListQuery} from '@/screens/home/hooks/useWorkspaceQuery';
@@ -54,40 +53,4 @@ export const useWorkspaceBottomSheet = () => {
   return {
     handleOpenBottomSheet,
   };
-};
-
-/**
- * 워크스페이스 정보 관리 훅
- * 유저 상태관리는 jotai 로 관리하고, 워크스페이스 정보는 AsyncStorage 에 저장합니다.
- * 워크스페이스 정보는 초기화 되어있지 않으면 초기화 상태로 설정합니다.
- * @author 홍규진
- */
-export const useWorkspace = () => {
-  const [workspace] = useAtom(workspaceState);
-
-  return {
-    workspace,
-    rootDirId: workspace.rootDirId,
-    workspaceId: workspace.workspaceId,
-    isValidWorkspace: workspace.isValidWorkspace,
-  };
-};
-
-/**
- * 워크스페이스 초기화 상태 체크 훅
- * 최초 접속 시 LANDING으로 이동하고, 워크스페이스가 없을 때만 INIT_WORKSPACE로 이동합니다.
- * @param isInit - true: INIT_WORKSPACE 화면에서 호출, false: LANDING 화면에서 호출
- */
-export const useWorkspaceInit = (isInit: boolean) => {
-  const [workspace] = useAtom(workspaceState);
-  const navigation = useTypeSafeNavigation();
-  console.log('workspace', workspace);
-  useEffect(() => {
-    //유효하지 않으면 보내고, 유효하면 초기화 상태 체크후 보내기
-    if (workspace.isValidWorkspace && isInit) {
-      navigation.replace('LANDING', {});
-    }
-  }, [navigation, workspace.isValidWorkspace, isInit]);
-
-  return workspace;
 };

--- a/src/navigation/navigator.tsx
+++ b/src/navigation/navigator.tsx
@@ -14,6 +14,7 @@ import {
   MemberScreen,
   LoginScreen,
   CreateWorkspaceScreen,
+  EditWorkspaceScreen,
 } from '@/screens';
 import {Header} from '@/components/Header';
 import {RecordingScreen} from '@/screens/recording';
@@ -87,6 +88,11 @@ export default function AppNavigator() {
         <Stack.Screen
           name="SECRETARY"
           component={SecretaryNavigator}
+          options={{headerShown: true, header: () => <Header />}}
+        />
+        <Stack.Screen
+          name="EDIT_WORKSPACE"
+          component={EditWorkspaceScreen}
           options={{headerShown: true, header: () => <Header />}}
         />
       </Stack.Navigator>

--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -23,5 +23,6 @@ export type TRouteParams = {
   RECORDING: {templateId: string};
   INIT_WORKSPACE: {};
   CREATE_WORKSPACE: {};
+  EDIT_WORKSPACE: {};
   SECRETARY: {};
 };

--- a/src/screens/calendar/hooks/useCalendar.ts
+++ b/src/screens/calendar/hooks/useCalendar.ts
@@ -9,7 +9,8 @@ import {getMonth, isSameMonth} from '../utils/formatDate';
 import {TPostScheduleRequest} from '@/services/calendar/types';
 import {createSchedule} from '@/services/calendar';
 import {useCalendarQuery} from './useCalendarQuery';
-import {useWorkspace} from '@/hooks/useWorkspace';
+import {useAtom} from 'jotai';
+import {workspaceState} from '@/atoms/workspace';
 
 /**
  * 캘린더 일정을 필터링하고, 생성하는 훅입니다.
@@ -18,7 +19,7 @@ import {useWorkspace} from '@/hooks/useWorkspace';
  */
 export const useCalendar = () => {
   const {openBottomSheet, closeBottomSheet} = useBottomSheet();
-  const {workspaceId} = useWorkspace();
+  const [workspace] = useAtom(workspaceState);
   const theme = useTheme();
 
   // 선택된 달
@@ -29,7 +30,7 @@ export const useCalendar = () => {
   // 선택된 날짜
   const [focusedDate, setFocusedDate] = useState<string | null>(null);
 
-  const {data: scheduleListData = []} = useCalendarQuery(workspaceId);
+  const {data: scheduleListData = []} = useCalendarQuery(workspace.workspaceId);
 
   // markedDates 생성
   const currentMarkedDates = useMemo(() => {

--- a/src/screens/edit-workspace/hooks/useDeleteWorkspaceMutation.tsx
+++ b/src/screens/edit-workspace/hooks/useDeleteWorkspaceMutation.tsx
@@ -1,0 +1,44 @@
+import {useMutation, useQueryClient} from '@tanstack/react-query';
+import {deleteWorkspaceMutationKey} from '@/constants/mutationKeys';
+import useTypeSafeNavigation from '@/hooks/useTypeSafeNavigaion';
+import {useModal} from '@/contexts/modal/ModalContext';
+import CommonModal from '@/components/CommonModal';
+
+/**
+ * 워크스페이스 삭제 뮤테이션 훅입니다.
+ * 워크스페이스 삭제 요청을 처리합니다.
+ * 워크스페이스 삭제시에 워크스페이스 목록 조회 캐시를 무효화합니다.
+ * 성공시엔 성공 모달을 띄우고, 확인을 누를 시에 워크스페이스 수정 화면으로 이동합니다.
+ * @returns 워크스페이스 삭제 뮤테이션 함수
+ * @author 홍규진
+ */
+export const useDeleteWorkspaceMutation = () => {
+  const queryClient = useQueryClient();
+  const navigation = useTypeSafeNavigation();
+  const {setIsOpen, setModalContent} = useModal();
+  const {mutate} = useMutation({
+    mutationKey: deleteWorkspaceMutationKey().mutationKey,
+    mutationFn: (workspaceId: string) =>
+      deleteWorkspaceMutationKey().mutationFn(workspaceId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: deleteWorkspaceMutationKey().mutationSuccessKey,
+      });
+      setIsOpen(true);
+      setModalContent(
+        <CommonModal
+          type={'check'}
+          title={'워크스페이스 삭제 완료'}
+          isCenter={true}
+          onConfirm={() => {
+            navigation.replace('INIT_WORKSPACE', {});
+          }}
+        />,
+      );
+    },
+  });
+
+  return {
+    mutate,
+  };
+};

--- a/src/screens/edit-workspace/hooks/useEditWorkspace.tsx
+++ b/src/screens/edit-workspace/hooks/useEditWorkspace.tsx
@@ -1,0 +1,76 @@
+import {useState} from 'react';
+import {launchImageLibrary} from 'react-native-image-picker';
+import {useEditWorkspaceMutation} from './useEditWorkspaceMutation';
+import {useAtom} from 'jotai';
+import {workspaceState} from '@/atoms/workspace';
+import {useDeleteWorkspaceMutation} from './useDeleteWorkspaceMutation';
+import {useModal} from '@/contexts/modal/ModalContext';
+import {CommonModal} from '@/components';
+
+/**
+ * 워크스페이스 수정 훅입니다.
+ * 워크스페이스 수정 화면에 필요한 상태와 함수를 제공합니다.
+ * 워크스페이스 수정 뮤테이션을 호출합니다.
+ * @author 홍규진
+ */
+export function useEditWorkspace() {
+  const [workspace] = useAtom(workspaceState);
+  const [name, setName] = useState('');
+  const [desc, setDesc] = useState('');
+  const [image, setImage] = useState<string | null>(null);
+  const [members, setMembers] = useState<string[]>([]);
+  const {mutate: editWorkspace} = useEditWorkspaceMutation();
+  const {mutate: deleteWorkspace} = useDeleteWorkspaceMutation();
+  const {setIsOpen, setModalContent} = useModal();
+
+  const handleSelectPhoto = async () => {
+    const result = await launchImageLibrary({
+      mediaType: 'photo',
+      selectionLimit: 1,
+    });
+    if (result.assets && result.assets.length > 0) {
+      setImage(result.assets[0].uri || null);
+    }
+  };
+
+  const handleEditWorkspace = () => {
+    editWorkspace({
+      workspaceId: workspace.workspaceId,
+      workspaceName: name,
+      workspaceDescription: desc,
+      inviteEmailList: members.map(email => ({email})),
+      imageUri: image || undefined,
+    });
+  };
+
+  const handleDeleteWorkspace = () => {
+    setIsOpen(true);
+    setModalContent(
+      <CommonModal
+        type={'default'}
+        title={'워크스페이스 삭제하기'}
+        content="정말로 워크스페이스를 삭제하시겠습니까?"
+        isCenter={true}
+        onConfirm={() => {
+          deleteWorkspace(workspace.workspaceId);
+        }}
+        onCancel={() => {
+          setIsOpen(false);
+        }}
+      />,
+    );
+  };
+  return {
+    name,
+    setName,
+    desc,
+    setDesc,
+    image,
+    setImage,
+    handleSelectPhoto,
+    members,
+    setMembers,
+    handleEditWorkspace,
+    handleDeleteWorkspace,
+  };
+}

--- a/src/screens/edit-workspace/hooks/useEditWorkspaceMutation.tsx
+++ b/src/screens/edit-workspace/hooks/useEditWorkspaceMutation.tsx
@@ -1,0 +1,49 @@
+import {useMutation, useQueryClient} from '@tanstack/react-query';
+import {TEditWorkspaceRequest} from '@/services/workspace/types';
+import {editWorkspaceMutationKey} from '@/constants/mutationKeys';
+import useTypeSafeNavigation from '@/hooks/useTypeSafeNavigaion';
+import {useModal} from '@/contexts/modal/ModalContext';
+import CommonModal from '@/components/CommonModal';
+import {useAtom} from 'jotai';
+import {workspaceState} from '@/atoms/workspace';
+
+/**
+ * 워크스페이스 수정 뮤테이션 훅입니다.
+ * 워크스페이스 수정 요청을 처리합니다.
+ * 워크스페이스 수정시에 워크스페이스 목록 조회 캐시를 무효화합니다.
+ * 성공시엔 성공 모달을 띄우고, 확인을 누를 시에 워크스페이스 수정 화면으로 이동합니다.
+ * @returns 워크스페이스 수정 뮤테이션 함수
+ * @author 홍규진
+ */
+export const useEditWorkspaceMutation = () => {
+  const queryClient = useQueryClient();
+  const navigation = useTypeSafeNavigation();
+  const {setIsOpen, setModalContent} = useModal();
+  const [workspace] = useAtom(workspaceState);
+  const {mutate} = useMutation({
+    mutationKey: editWorkspaceMutationKey(workspace.workspaceId).mutationKey,
+    mutationFn: (workspace: TEditWorkspaceRequest) =>
+      editWorkspaceMutationKey(workspace.workspaceId).mutationFn(workspace),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: editWorkspaceMutationKey(workspace.workspaceId)
+          .mutationSuccessKey,
+      });
+      setIsOpen(true);
+      setModalContent(
+        <CommonModal
+          type={'check'}
+          title={'워크스페이스 수정 완료'}
+          isCenter={true}
+          onConfirm={() => {
+            navigation.navigate('LANDING', {});
+          }}
+        />,
+      );
+    },
+  });
+
+  return {
+    mutate,
+  };
+};

--- a/src/screens/edit-workspace/index.style.ts
+++ b/src/screens/edit-workspace/index.style.ts
@@ -1,0 +1,89 @@
+import styled from '@emotion/native';
+
+export const Container = styled.ScrollView`
+  flex: 1;
+  background-color: ${({theme}) => theme.colors.background};
+  padding: 20px 24px;
+`;
+
+export const Title = styled.Text`
+  ${({theme}) => theme.fonts.title2};
+  color: ${({theme}) => theme.colors.textPrimary};
+  text-align: center;
+  margin-bottom: 8px;
+`;
+
+export const ImageWrapper = styled.View`
+  align-items: center;
+  margin-top: 40px;
+  margin-bottom: 24px;
+`;
+
+export const ProfileCircle = styled.TouchableOpacity`
+  width: 120px;
+  height: 120px;
+  border-radius: 60px;
+  background-color: ${({theme}) => theme.colors.white};
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 8px;
+  box-shadow: 0px 2px 8px rgba(0, 0, 0, 0.08);
+`;
+
+export const ProfileText = styled.Text`
+  ${({theme}) => theme.fonts.title1};
+  color: ${({theme}) => theme.colors.white};
+`;
+
+export const SelectPhoto = styled.Text`
+  ${({theme}) => theme.fonts.text2};
+  color: ${({theme}) => theme.colors.blue};
+  text-align: center;
+  margin-bottom: 16px;
+`;
+
+export const Label = styled.Text`
+  ${({theme}) => theme.fonts.text2};
+  color: ${({theme}) => theme.colors.textPrimary};
+  margin-bottom: 8px;
+  margin-top: 16px;
+`;
+
+export const Input = styled.TextInput`
+  ${({theme}) => theme.fonts.text2};
+  color: ${({theme}) => theme.colors.textPrimary};
+  border-bottom-width: 1px;
+  border-bottom-color: ${({theme}) => theme.colors.divider};
+  padding: 8px 0;
+  margin-bottom: 4px;
+`;
+
+export const InputCount = styled.Text`
+  ${({theme}) => theme.fonts.text2};
+  color: ${({theme}) => theme.colors.textPrimary};
+  text-align: right;
+  margin-bottom: 8px;
+`;
+
+export const SubmitButton = styled.TouchableOpacity`
+  background-color: ${({theme}) => theme.colors.blue};
+  margin-top: 30px;
+  border-radius: 24px;
+  height: 52px;
+  align-items: center;
+  justify-content: center;
+`;
+
+export const SubmitButtonText = styled.Text`
+  ${({theme}) => theme.fonts.title3};
+  color: ${({theme}) => theme.colors.white};
+`;
+
+export const DeleteButton = styled.TouchableOpacity`
+  background-color: ${({theme}) => theme.colors.red};
+  margin-top: 30px;
+  border-radius: 24px;
+  height: 52px;
+  align-items: center;
+  justify-content: center;
+`;

--- a/src/screens/edit-workspace/index.tsx
+++ b/src/screens/edit-workspace/index.tsx
@@ -1,0 +1,99 @@
+import React, {useEffect, useState} from 'react';
+import {
+  Container,
+  ImageWrapper,
+  ProfileCircle,
+  ProfileText,
+  SelectPhoto,
+  Label,
+  Input,
+  InputCount,
+  SubmitButton,
+  SubmitButtonText,
+  DeleteButton,
+} from './index.style';
+import {TopBar} from '@/components/TopBar';
+import useTypeSafeNavigation from '@/hooks/useTypeSafeNavigaion';
+import {Image} from 'react-native';
+
+import {useEditWorkspace} from './hooks/useEditWorkspace';
+import {useTheme} from '@emotion/react';
+import {useWorkspaceQuery} from '../home/hooks/useWorkspaceQuery';
+
+export const EditWorkspaceScreen = () => {
+  const theme = useTheme();
+  const navigation = useTypeSafeNavigation();
+  const {data: workspace} = useWorkspaceQuery();
+  const [selectedImage, setSelectedImage] = useState<string | null>(null);
+  const {
+    name,
+    setName,
+    desc,
+    setDesc,
+    image,
+    handleSelectPhoto,
+    handleEditWorkspace,
+    handleDeleteWorkspace,
+  } = useEditWorkspace();
+
+  useEffect(() => {
+    setName(workspace?.workspaceName ?? '');
+    setDesc(workspace?.workspaceDescription ?? '');
+  }, [workspace, setName, setDesc]);
+
+  const handleImageSelect = async () => {
+    const result = await handleSelectPhoto();
+    setSelectedImage(result ?? null);
+  };
+
+  return (
+    <Container>
+      <TopBar
+        title="워크스페이스 수정"
+        showBackButton={true}
+        onPressBack={() => navigation.navigate('LANDING', {})}
+      />
+      <ImageWrapper>
+        <ProfileCircle onPress={handleImageSelect}>
+          {selectedImage || workspace?.imageUrl ? (
+            <Image
+              source={{uri: image ?? workspace?.imageUrl}}
+              style={{width: 120, height: 120, borderRadius: 60}}
+            />
+          ) : (
+            <ProfileText>대표 사진</ProfileText>
+          )}
+        </ProfileCircle>
+        <SelectPhoto onPress={handleImageSelect}>사진 선택하기</SelectPhoto>
+      </ImageWrapper>
+
+      <Label>워크스페이스 이름</Label>
+      <Input
+        placeholder="워크스페이스 이름을 입력하세요"
+        placeholderTextColor={theme.colors.textDisabled}
+        value={name}
+        onChangeText={setName}
+        maxLength={20}
+      />
+      <InputCount>{name.length}/20</InputCount>
+
+      <Label>워크스페이스 소개</Label>
+      <Input
+        placeholder="워크스페이스 소개를 입력하세요"
+        placeholderTextColor={theme.colors.textDisabled}
+        value={desc}
+        onChangeText={setDesc}
+        maxLength={200}
+        multiline
+      />
+      <InputCount>{desc.length}/200</InputCount>
+
+      <SubmitButton onPress={handleEditWorkspace}>
+        <SubmitButtonText>수정하기</SubmitButtonText>
+      </SubmitButton>
+      <DeleteButton onPress={handleDeleteWorkspace}>
+        <SubmitButtonText>워크스페이스 삭제하기</SubmitButtonText>
+      </DeleteButton>
+    </Container>
+  );
+};

--- a/src/screens/file/hooks/useFile.ts
+++ b/src/screens/file/hooks/useFile.ts
@@ -1,8 +1,10 @@
 // src/screens/file/hooks/useFile.ts
 import {useState} from 'react';
 // import {data} from '../constants/mockData';
-import {useWorkspace} from '@/hooks/useWorkspace';
+
 import {useFileQuery} from './useFileQuery';
+import {useAtom} from 'jotai';
+import {workspaceState} from '@/atoms/workspace';
 
 // import {useFileQuery} from './useFileQuery';
 /**
@@ -15,8 +17,11 @@ import {useFileQuery} from './useFileQuery';
  */
 export const useFile = () => {
   const [search, setSearch] = useState('');
-  const {workspaceId, rootDirId} = useWorkspace();
-  const {data} = useFileQuery(workspaceId, parseInt(rootDirId, 10));
+  const [workspace] = useAtom(workspaceState);
+  const {data} = useFileQuery(
+    workspace.workspaceId,
+    parseInt(workspace.rootDirId, 10),
+  );
   const filteredFolders = data.directoryList.filter(folder =>
     folder.dirName.includes(search),
   );

--- a/src/screens/file/index.tsx
+++ b/src/screens/file/index.tsx
@@ -13,17 +13,19 @@ import {FilePreview} from '@/components/FilePreview';
 import {FolderData} from '@/components/FolderPreview/index.type';
 import {FileData} from '@/components/FilePreview/index.type';
 import {useFile} from './hooks/useFile';
-import {useWorkspace} from '@/hooks/useWorkspace';
+
 import CommonModal from '@/components/CommonModal';
 import {useAddFileMutation} from './hooks/uesFileMutation';
 import {useModal} from '@/contexts/modal/ModalContext';
+import {useAtom} from 'jotai';
+import {workspaceState} from '@/atoms/workspace';
 
 export const FileScreen: React.FC = () => {
-  const {workspaceId, workspace: workspaceInfo, rootDirId} = useWorkspace();
+  const [workspace] = useAtom(workspaceState);
   const {setIsOpen, setModalContent} = useModal();
   const {mutate: addFileMutation} = useAddFileMutation(
-    workspaceId!,
-    parseInt(rootDirId, 10),
+    workspace.workspaceId,
+    parseInt(workspace.rootDirId, 10),
   );
 
   const {setSearch, mergedList, filteredFolders, filteredFiles} = useFile();
@@ -43,8 +45,8 @@ export const FileScreen: React.FC = () => {
                 inputPlaceholder="폴더 이름을 입력하세요"
                 onConfirm={inputValue => {
                   addFileMutation({
-                    workspaceId: workspaceId!,
-                    parentId: parseInt(rootDirId, 10),
+                    workspaceId: workspace.workspaceId,
+                    parentId: parseInt(workspace.rootDirId, 10),
                     directoryName: inputValue!,
                   });
                 }}
@@ -80,7 +82,7 @@ export const FileScreen: React.FC = () => {
               <ItemWrapper>
                 <FolderPreview
                   folder={item as FolderData}
-                  isAdmin={workspaceInfo.isAdmin}
+                  isAdmin={workspace.isAdmin}
                 />
               </ItemWrapper>
             );

--- a/src/screens/home/components/WorkspaceProfile/index.tsx
+++ b/src/screens/home/components/WorkspaceProfile/index.tsx
@@ -13,6 +13,8 @@ import {MemberIcon, MoreIcon} from '@assets/images/svg/home';
 import {useThemeColors} from '@contexts/theme/ThemeContext';
 import {LogoIcon} from '@assets/images/svg/common';
 import useTypeSafeNavigation from '@/hooks/useTypeSafeNavigaion';
+import {useAtom} from 'jotai';
+import {workspaceState} from '@/atoms/workspace';
 /**
  * 홈 화면 상단의 워크스페이스 프로필 컴포넌트입니다.
  * 워크스페이스의 이름, 설명, 이미지를 표시하며,
@@ -36,6 +38,7 @@ export const WorkspaceProfile = ({
 }: WorkspaceProfileProps) => {
   const {textPrimary} = useThemeColors();
   const navigation = useTypeSafeNavigation();
+  const [workspace] = useAtom(workspaceState);
   return (
     <Container onLayout={onLayout}>
       <ButtonContainer>
@@ -45,7 +48,16 @@ export const WorkspaceProfile = ({
           height={21}
           onPress={() => navigation.navigate('MEMBER', {})}
         />
-        <MoreIcon fill={textPrimary} width={21} height={21} />
+        <MoreIcon
+          fill={textPrimary}
+          width={21}
+          height={21}
+          onPress={() => {
+            if (workspace.isAdmin) {
+              navigation.navigate('EDIT_WORKSPACE', {});
+            }
+          }}
+        />
       </ButtonContainer>
       <ProfileContainer>
         <ImageContainer>

--- a/src/screens/home/hooks/useCategoryListQuery.ts
+++ b/src/screens/home/hooks/useCategoryListQuery.ts
@@ -1,7 +1,9 @@
 import {DEFAULT_WORKSPACE_ID} from '@/atoms/workspace/types';
 import {categoryListQuery} from '@/constants/queryKeys';
-import {useWorkspace} from '@/hooks/useWorkspace';
+
 import {useQuery} from '@tanstack/react-query';
+import {useAtom} from 'jotai';
+import {workspaceState} from '@/atoms/workspace';
 
 /**
  * 카테고리 목록 조회 훅
@@ -11,11 +13,11 @@ import {useQuery} from '@tanstack/react-query';
  */
 
 export const useCategoryListQuery = () => {
-  const {workspaceId} = useWorkspace();
+  const [workspace] = useAtom(workspaceState);
   const {data, refetch} = useQuery({
-    queryKey: categoryListQuery(workspaceId!).queryKey,
-    queryFn: categoryListQuery(workspaceId!).queryFn,
-    enabled: workspaceId !== DEFAULT_WORKSPACE_ID,
+    queryKey: categoryListQuery(workspace.workspaceId).queryKey,
+    queryFn: categoryListQuery(workspace.workspaceId).queryFn,
+    enabled: workspace.workspaceId !== DEFAULT_WORKSPACE_ID,
   });
 
   return {

--- a/src/screens/home/hooks/usePostMutation.ts
+++ b/src/screens/home/hooks/usePostMutation.ts
@@ -1,5 +1,5 @@
 import {useMutation, useQueryClient} from '@tanstack/react-query';
-import {useWorkspace} from '@hooks/useWorkspace';
+
 import {
   deletePostMutationKey,
   patchPostPinMutationKey,
@@ -7,6 +7,8 @@ import {
 import {TDeletePostRequest, TUpdatePostPinRequest} from '@/services/post/types';
 import {ROUTE_NAMES} from '@/constants/routes';
 import useTypeSafeNavigation from '@hooks/useTypeSafeNavigaion';
+import {useAtom} from 'jotai';
+import {workspaceState} from '@/atoms/workspace';
 
 /**
  * 게시글 핀 박기 뮤테이션 훅입니다.
@@ -17,15 +19,16 @@ import useTypeSafeNavigation from '@hooks/useTypeSafeNavigaion';
  */
 export const usePatchPostPinMutation = () => {
   const queryClient = useQueryClient();
-  const {workspaceId} = useWorkspace();
+  const [workspace] = useAtom(workspaceState);
   const {mutateAsync: patchPostPinMutation} = useMutation({
-    mutationKey: patchPostPinMutationKey(workspaceId!).mutationKey,
+    mutationKey: patchPostPinMutationKey(workspace.workspaceId).mutationKey,
     mutationFn: (request: TUpdatePostPinRequest) =>
-      patchPostPinMutationKey(workspaceId!).mutationFn(request),
+      patchPostPinMutationKey(workspace.workspaceId).mutationFn(request),
 
     onSuccess: () => {
       queryClient.invalidateQueries({
-        queryKey: patchPostPinMutationKey(workspaceId!).mutationSuccessKey,
+        queryKey: patchPostPinMutationKey(workspace.workspaceId)
+          .mutationSuccessKey,
       });
     },
   });
@@ -40,15 +43,16 @@ export const usePatchPostPinMutation = () => {
  */
 export const useDeletePostMutation = () => {
   const queryClient = useQueryClient();
-  const {workspaceId} = useWorkspace();
+  const [workspace] = useAtom(workspaceState);
   const navigation = useTypeSafeNavigation();
   const {mutateAsync: deletePostMutation} = useMutation({
-    mutationKey: deletePostMutationKey(workspaceId!).mutationKey,
+    mutationKey: deletePostMutationKey(workspace.workspaceId).mutationKey,
     mutationFn: (request: TDeletePostRequest) =>
-      deletePostMutationKey(workspaceId!).mutationFn(request),
+      deletePostMutationKey(workspace.workspaceId).mutationFn(request),
     onSuccess: () => {
       queryClient.invalidateQueries({
-        queryKey: deletePostMutationKey(workspaceId!).mutationSuccessKey,
+        queryKey: deletePostMutationKey(workspace.workspaceId)
+          .mutationSuccessKey,
       });
       navigation.navigate(ROUTE_NAMES.LANDING, {});
     },

--- a/src/screens/home/hooks/usePostQuery.ts
+++ b/src/screens/home/hooks/usePostQuery.ts
@@ -1,7 +1,8 @@
 import {DEFAULT_WORKSPACE_ID} from '@/atoms/workspace/types';
 import {postQuery} from '@/constants/queryKeys';
-import {useWorkspace} from '@hooks/useWorkspace';
 import {useQuery} from '@tanstack/react-query';
+import {useAtom} from 'jotai';
+import {workspaceState} from '@/atoms/workspace';
 
 /**
  * 게시글 목록 조회 훅
@@ -11,11 +12,11 @@ import {useQuery} from '@tanstack/react-query';
  */
 
 export const usePostQuery = () => {
-  const {workspaceId} = useWorkspace();
+  const [workspace] = useAtom(workspaceState);
   const {data, refetch} = useQuery({
-    queryKey: postQuery(workspaceId!).queryKey,
-    queryFn: postQuery(workspaceId!).queryFn,
-    enabled: workspaceId !== DEFAULT_WORKSPACE_ID,
+    queryKey: postQuery(workspace.workspaceId).queryKey,
+    queryFn: postQuery(workspace.workspaceId).queryFn,
+    enabled: workspace.workspaceId !== DEFAULT_WORKSPACE_ID,
   });
 
   return {

--- a/src/screens/home/hooks/useWorkspaceQuery.ts
+++ b/src/screens/home/hooks/useWorkspaceQuery.ts
@@ -1,7 +1,8 @@
 import {DEFAULT_WORKSPACE_ID} from '@/atoms/workspace/types';
 import {workspaceListQuery, workspaceQuery} from '@/constants/queryKeys';
-import {useWorkspace} from '@hooks/useWorkspace';
-import {useQuery, useSuspenseQuery} from '@tanstack/react-query';
+import {useQuery} from '@tanstack/react-query';
+import {useAtom} from 'jotai';
+import {workspaceState} from '@/atoms/workspace';
 
 /**
  * 워크스페이스 리스트 조회 훅
@@ -9,12 +10,14 @@ import {useQuery, useSuspenseQuery} from '@tanstack/react-query';
  * @author 홍규진
  */
 export const useWorkspaceListQuery = () => {
-  const {data} = useSuspenseQuery({
+  const {data, isLoading} = useQuery({
     queryKey: workspaceListQuery().queryKey,
     queryFn: workspaceListQuery().queryFn,
   });
+
   return {
     data,
+    isLoading,
   };
 };
 
@@ -24,13 +27,12 @@ export const useWorkspaceListQuery = () => {
  * @returns 워크스페이스 정보
  * @author 홍규진
  */
-
 export const useWorkspaceQuery = () => {
-  const {workspaceId} = useWorkspace();
+  const [workspace] = useAtom(workspaceState);
   const {data, refetch} = useQuery({
-    queryKey: workspaceQuery(workspaceId).queryKey,
-    queryFn: workspaceQuery(workspaceId).queryFn,
-    enabled: workspaceId !== DEFAULT_WORKSPACE_ID,
+    queryKey: workspaceQuery(workspace.workspaceId).queryKey,
+    queryFn: workspaceQuery(workspace.workspaceId).queryFn,
+    enabled: workspace.workspaceId !== DEFAULT_WORKSPACE_ID,
   });
   return {
     data,

--- a/src/screens/index.ts
+++ b/src/screens/index.ts
@@ -20,3 +20,4 @@ export * from './post-detail';
 export * from './member';
 export * from './init-workspace';
 export * from './create-workspace';
+export * from './edit-workspace';

--- a/src/screens/init-workspace/index.tsx
+++ b/src/screens/init-workspace/index.tsx
@@ -13,12 +13,11 @@ import enterWorkspaceImg from '@/assets/images/png/workspace/enter_workspace.png
 import LinearGradient from 'react-native-linear-gradient';
 import {useTheme} from '@/contexts/theme/ThemeContext';
 import {GenDLogoIcon} from '@/assets/images/svg/common';
-import {useWorkspaceBottomSheet, useWorkspaceInit} from '@/hooks/useWorkspace';
 import useTypeSafeNavigation from '@/hooks/useTypeSafeNavigaion';
+import {useWorkspaceBottomSheet} from '@/hooks/useWorkspaceBottomSheet';
 
 export const InitWorkspaceScreen = () => {
   const theme = useTheme();
-  useWorkspaceInit(true);
   const {handleOpenBottomSheet} = useWorkspaceBottomSheet();
   const navigation = useTypeSafeNavigation();
 

--- a/src/screens/login/hooks/useOauthLoginMutation.ts
+++ b/src/screens/login/hooks/useOauthLoginMutation.ts
@@ -2,8 +2,6 @@ import useTypeSafeNavigation from '@/hooks/useTypeSafeNavigaion';
 import {afterKakaoLogin, initiateKakaoLogin} from '@/services/auth';
 import {setAccessToken, setRefreshToken} from '@/utils/auth';
 import {useMutation} from '@tanstack/react-query';
-import {useAtom} from 'jotai';
-import {isSignedInAtom} from '@/atoms/auth';
 
 /**
  * 카카오 로그인 뮤테이션 훅입니다.
@@ -15,8 +13,6 @@ import {isSignedInAtom} from '@/atoms/auth';
  */
 export const useKakaoLoginMutation = (fcmToken: string) => {
   const navigation = useTypeSafeNavigation();
-  const [, setIsSignedIn] = useAtom(isSignedInAtom);
-
   const mutation = useMutation({
     mutationKey: ['kakaoLogin'],
     mutationFn: () => initiateKakaoLogin(),
@@ -33,15 +29,16 @@ export const useKakaoLoginMutation = (fcmToken: string) => {
         console.log('accessToken', loginResponse.jwtTokenDto.accessToken);
         setRefreshToken(loginResponse.jwtTokenDto.refreshToken);
         console.log('refreshToken', loginResponse.jwtTokenDto.refreshToken);
-        setIsSignedIn(true); // 로그인 상태 업데이트
+        // 500ms 후에 워크스페이스 초기화 페이지로 이동
+        setTimeout(() => {
+          navigation.navigate('INIT_WORKSPACE', {});
+          console.log('INIT_WORKSPACE으로 리디렉션');
+        }, 500);
       }
-      // 홈으로 리디렉션
-      navigation.replace('INIT_WORKSPACE', {});
     },
     onError: (error: Error) => {
       // 로그인 실패 시 처리
       console.error('로그인 실패:', error);
-      setIsSignedIn(false);
     },
   });
 

--- a/src/screens/member/hooks/useMemberMutation.ts
+++ b/src/screens/member/hooks/useMemberMutation.ts
@@ -9,7 +9,8 @@ import {
   memberUpdateMutationKey,
   memberAddMutationKey,
 } from '@/constants/mutationKeys';
-import {useWorkspace} from '@hooks/useWorkspace';
+import {useAtom} from 'jotai';
+import {workspaceState} from '@/atoms/workspace';
 
 /**
  * 멤버 추가 뮤테이션 훅입니다.
@@ -19,15 +20,19 @@ import {useWorkspace} from '@hooks/useWorkspace';
  * @author 홍규진
  */
 export const useAddMemberMutation = () => {
-  const {workspaceId} = useWorkspace();
+  const [workspace] = useAtom(workspaceState);
   const queryClient = useQueryClient();
   const {mutateAsync} = useMutation({
-    mutationKey: memberAddMutationKey(workspaceId!).mutationKey,
+    mutationKey: memberAddMutationKey(workspace.workspaceId).mutationKey,
     mutationFn: ({workspaceId, email}: {workspaceId: string; email: string}) =>
-      memberAddMutationKey(workspaceId!).mutationFn(workspaceId, email),
+      memberAddMutationKey(workspace.workspaceId).mutationFn(
+        workspaceId,
+        email,
+      ),
     onSuccess: () => {
       queryClient.invalidateQueries({
-        queryKey: memberAddMutationKey(workspaceId!).mutationSuccessKey,
+        queryKey: memberAddMutationKey(workspace.workspaceId)
+          .mutationSuccessKey,
       });
     },
   });
@@ -44,15 +49,16 @@ export const useAddMemberMutation = () => {
  * @author 홍규진
  */
 export const useModifyMemberRoleMutation = () => {
-  const {workspaceId} = useWorkspace();
+  const [workspace] = useAtom(workspaceState);
   const queryClient = useQueryClient();
   const {mutateAsync} = useMutation({
-    mutationKey: memberUpdateMutationKey(workspaceId!).mutationKey,
+    mutationKey: memberUpdateMutationKey(workspace.workspaceId).mutationKey,
     mutationFn: (member: TUpdateMemberRequest) =>
-      memberUpdateMutationKey(workspaceId!).mutationFn(member),
+      memberUpdateMutationKey(workspace.workspaceId).mutationFn(member),
     onSuccess: () => {
       queryClient.invalidateQueries({
-        queryKey: memberUpdateMutationKey(workspaceId!).mutationSuccessKey,
+        queryKey: memberUpdateMutationKey(workspace.workspaceId)
+          .mutationSuccessKey,
       });
     },
   });
@@ -70,16 +76,20 @@ export const useModifyMemberRoleMutation = () => {
  * @author 홍규진
  */
 export const useDeleteMemberMutation = () => {
-  const {workspaceId} = useWorkspace();
+  const [workspace] = useAtom(workspaceState);
   const queryClient = useQueryClient();
   const {setIsOpen} = useModal();
   const {mutateAsync} = useMutation({
-    mutationKey: memberDeleteMutationKey(workspaceId!).mutationKey,
+    mutationKey: memberDeleteMutationKey(workspace.workspaceId).mutationKey,
     mutationFn: ({workspaceId, memberId}: TDeleteMemberRequest) =>
-      memberDeleteMutationKey(workspaceId!).mutationFn({workspaceId, memberId}),
+      memberDeleteMutationKey(workspace.workspaceId).mutationFn({
+        workspaceId,
+        memberId,
+      }),
     onSuccess: () => {
       queryClient.invalidateQueries({
-        queryKey: memberDeleteMutationKey(workspaceId!).mutationSuccessKey,
+        queryKey: memberDeleteMutationKey(workspace.workspaceId)
+          .mutationSuccessKey,
       });
       setIsOpen(false);
     },

--- a/src/screens/member/index.tsx
+++ b/src/screens/member/index.tsx
@@ -11,13 +11,14 @@ import {MemberProfile} from '@/components/MemberProfile';
 import {SearchBar} from '@/components/SearchBar';
 import {useMemberListQuery} from './hooks/useMemberListQuery';
 import {RefreshControl} from 'react-native';
-import {useWorkspace} from '@hooks/useWorkspace';
 import {PlusIcon} from '@/assets/images/svg/common';
 import {useTheme} from '@/contexts/theme/ThemeContext';
 import {useModal} from '@/contexts/modal/ModalContext';
 import {AddMemberModal} from './components/AddMemberModal';
 import CommonModal from '@/components/CommonModal';
 import {useAddMemberMutation} from './hooks/useMemberMutation';
+import {useAtom} from 'jotai';
+import {workspaceState} from '@/atoms/workspace';
 
 /**
  * 멤버 리스트 화면입니다.
@@ -28,9 +29,9 @@ import {useAddMemberMutation} from './hooks/useMemberMutation';
 export const MemberScreen = () => {
   const theme = useTheme();
   const [search, setSearch] = useState('');
-  const {workspaceId} = useWorkspace();
+  const [workspace] = useAtom(workspaceState);
   const {data: memberList, refetch: refetchMemberList} = useMemberListQuery(
-    workspaceId ?? '-1',
+    workspace.workspaceId,
   );
   const {mutateAsync: addMember} = useAddMemberMutation();
   const {setIsOpen, setModalContent} = useModal();
@@ -71,7 +72,7 @@ export const MemberScreen = () => {
                   <AddMemberModal
                     onAdd={email => {
                       addMember({
-                        workspaceId: workspaceId ?? '-1',
+                        workspaceId: workspace.workspaceId,
                         email,
                       });
                     }}

--- a/src/screens/recording/hooks/useRecord.ts
+++ b/src/screens/recording/hooks/useRecord.ts
@@ -3,8 +3,8 @@ import {useState, useEffect, useRef, useCallback} from 'react';
 import AudioRecorderPlayer from 'react-native-audio-recorder-player';
 import {Platform, PermissionsAndroid} from 'react-native';
 import {useDirectoryListQuery} from './useRecordQuery';
-import {useWorkspace} from '@/hooks/useWorkspace';
-// import {useWorkspace} from '@/contexts/workspace/WorkspaceContenxt';
+import {useAtom} from 'jotai';
+import {workspaceState} from '@/atoms/workspace';
 /**
  * 녹음 기능 관련 훅입니다.
  * @author 홍규진
@@ -17,8 +17,8 @@ export type RecordError = {
 };
 
 export function useRecord() {
-  const {workspaceId} = useWorkspace();
-  const {data: directoryList} = useDirectoryListQuery(workspaceId);
+  const [workspace] = useAtom(workspaceState);
+  const {data: directoryList} = useDirectoryListQuery(workspace.workspaceId);
 
   const [isRecording, setIsRecording] = useState(false);
   const [isPaused, setIsPaused] = useState(false);

--- a/src/screens/secretary/contexts/ChatContext.tsx
+++ b/src/screens/secretary/contexts/ChatContext.tsx
@@ -2,8 +2,9 @@ import React, {createContext, useContext, useState} from 'react';
 import {ChatMessage} from '../types';
 import {useChattingMutation} from '../hooks/useChattingMutation';
 import {TPostChattingRequest} from '@/services/secretary/types';
-import {useWorkspace} from '@hooks/useWorkspace';
 import {formatTime} from '../utils/formatTime';
+import {useAtom} from 'jotai';
+import {workspaceState} from '@/atoms/workspace';
 
 /**
  * 채팅 메시지를 지역적으로 관리하는 컨텍스트 파일입니다.
@@ -25,7 +26,7 @@ const ChatContext = createContext<ChatContextType | undefined>(undefined);
 export const ChatProvider = ({children}: {children: React.ReactNode}) => {
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const {mutate: sendChatting, isPending} = useChattingMutation();
-  const {workspaceId} = useWorkspace();
+  const [workspace] = useAtom(workspaceState);
   const addMessage = (msg: ChatMessage) => setMessages(prev => [...prev, msg]);
 
   const handleSendChatting = (request: TPostChattingRequest) => {
@@ -37,7 +38,7 @@ export const ChatProvider = ({children}: {children: React.ReactNode}) => {
     });
     sendChatting(
       {
-        workSpaceId: workspaceId!,
+        workSpaceId: workspace.workspaceId,
         request,
       },
       {

--- a/src/screens/write/hooks/useWriteMutation.tsx
+++ b/src/screens/write/hooks/useWriteMutation.tsx
@@ -5,7 +5,8 @@ import {Asset} from 'react-native-image-picker';
 import {useMutation, useQueryClient} from '@tanstack/react-query';
 import {useModal} from '@contexts/modal/ModalContext';
 import CommonModal from '@components/CommonModal';
-import {useWorkspace} from '@hooks/useWorkspace';
+import {useAtom} from 'jotai';
+import {workspaceState} from '@/atoms/workspace';
 
 type TWriteMutationVariables = {
   request: TPostWriteRequest;
@@ -22,12 +23,12 @@ export const useWriteMutation = () => {
   const queryClient = useQueryClient();
   const navigation = useTypeSafeNavigation();
   const {setIsOpen, setModalContent} = useModal();
-  const {workspaceId} = useWorkspace();
+  const [workspace] = useAtom(workspaceState);
 
   const mutation = useMutation({
     mutationKey: ['write'],
     mutationFn: ({request, imageFile}: TWriteMutationVariables) => {
-      return createPost(workspaceId!, request, imageFile);
+      return createPost(workspace.workspaceId, request, imageFile);
     },
 
     onSuccess: async () => {

--- a/src/services/workspace/index.ts
+++ b/src/services/workspace/index.ts
@@ -2,6 +2,7 @@ import {privateServerInstance} from '../api/axios';
 import {TGetResponse} from '../api/type';
 import {
   TCreateWorkspaceRequest,
+  TEditWorkspaceRequest,
   TGetWorkspaceInfoResponse,
   TGetWorkspaceListResponse,
 } from './types';
@@ -74,4 +75,57 @@ export const createWorkspace = async (
   );
 
   return response.data.data;
+};
+
+/**
+ * 워크스페이스 생성 API 호출 함수입니다.
+ * @author 홍규진
+ */
+export const editWorkspace = async (
+  workspace: TEditWorkspaceRequest & {imageUri?: string},
+): Promise<boolean> => {
+  const formData = new FormData();
+
+  // 이미지가 있으면 추가
+  formData.append('image', {
+    uri: workspace.imageUri,
+    type: 'image/jpeg', // 또는 실제 타입
+    name: 'workspace.jpg', // 또는 실제 파일명
+  });
+
+  // JSON 데이터 추가
+  const jsonPayload = {
+    workspaceName: workspace.workspaceName,
+    workspaceDescription: workspace.workspaceDescription,
+    inviteEmailList: workspace.inviteEmailList,
+  };
+
+  // 워크스페이스 데이터를 FormData에 추가 application/json 으로 지정해야만 함.
+  formData.append('json', {
+    uri:
+      'data:application/json;charset=utf-8,' +
+      encodeURIComponent(JSON.stringify(jsonPayload)),
+    type: 'application/json',
+    name: 'workspace.json',
+  });
+
+  const response = await privateServerInstance.patch(
+    `/api/v1/workspaces/${workspace.workspaceId}`,
+    formData,
+    {
+      headers: {
+        'Content-Type': 'multipart/form-data',
+      },
+    },
+  );
+
+  return response.data.data;
+};
+
+/**
+ * 워크스페이스 삭제 API 호출 함수입니다.
+ * @author 홍규진
+ */
+export const deleteWorkspace = async (workspaceId: string): Promise<void> => {
+  await privateServerInstance.delete(`/api/v1/workspaces/${workspaceId}`);
 };

--- a/src/services/workspace/types.ts
+++ b/src/services/workspace/types.ts
@@ -26,9 +26,25 @@ export type TGetWorkspaceListResponse = {
  */
 export type TGetWorkspaceInfoResponse = TWorkspace;
 
+/**
+ * 워크스페이스 생성 요청 타입입니다.
+ * @author 홍규진
+ */
 export type TCreateWorkspaceRequest = {
   imageUri?: string;
   workspaceName: string;
   workspaceDescription: string;
   inviteEmailList: {email: string}[];
+};
+
+/**
+ * 워크스페이스 수정 요청 타입입니다.
+ * @author 홍규진
+ */
+export type TEditWorkspaceRequest = {
+  workspaceId: string;
+  imageUri?: string;
+  workspaceName?: string;
+  workspaceDescription?: string;
+  inviteEmailList?: {email: string}[];
 };


### PR DESCRIPTION
## 관련 이슈

- Resolves : #77 
 
## 작업 사항
### 상태관리 마이그레이션 
- 기존에 AuthContext로 관리하던, 인증(로그인) 여부 상태관리를 Jotai로 마이그레이션 합니다.
- 기존에 WorkspaceContext 로 관리하던, 워크스페이스 상태관리를 Jotai로 마이그레이션 합니다.
- useAuth() , useWorkspace 를 통해 너무 빈번하게 호출되었던 상태를 수정합니다.
- hook 내부의 hook 이 호출되어 연쇄적으로 파생되는 상태를 관리하기가 점차 힘들어져서 이를 Jotai로 수정합니다.
- Provider Wrapper를 통해 지역 혹은 전역적인 상태관리를 하다보니, Provider 의 상하 관계에 따른 호출 불가능한 상태에 따라 이를 완전히 통제합니다.
### 워크스페이스 수정, 삭제 기능 구현
![Simulator Screen Recording - Poppin_Simulator - 2025-05-28 at 03 24 51](https://github.com/user-attachments/assets/170a3767-68f6-4430-bcc2-2c65546077a1)

## 참고 사항
기능을 만들 때 생긴 이슈에 대해서 다른사람들이 참고해야 할 사항을 적습니다.
